### PR TITLE
Jest-styled-components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1008,6 +1008,12 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
+    "atob": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/atob/-/atob-1.1.3.tgz",
+      "integrity": "sha1-lfE2KbEsOlGl0hWr3OKqnzL4B3M=",
+      "dev": true
+    },
     "autoprefixer": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-7.2.4.tgz",
@@ -2725,6 +2731,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
+        "fsevents": "1.1.3",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3228,6 +3235,29 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+    },
+    "css": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/css/-/css-2.2.1.tgz",
+      "integrity": "sha1-c6TIHehdtmTU7mdPfUcIXjstVdw=",
+      "dev": true,
+      "requires": {
+        "inherits": "2.0.3",
+        "source-map": "0.1.43",
+        "source-map-resolve": "0.3.1",
+        "urix": "0.1.0"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.43",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+          "integrity": "sha1-wkvBRspRfBRx9drL4lcbK3+eM0Y=",
+          "dev": true,
+          "requires": {
+            "amdefine": "1.0.1"
+          }
+        }
+      }
     },
     "css-color-keywords": {
       "version": "1.0.0",
@@ -4850,6 +4880,795 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
+    "fsevents": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
+      "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+      "optional": true,
+      "requires": {
+        "nan": "2.8.0",
+        "node-pre-gyp": "0.6.39"
+      },
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "bundled": true,
+          "optional": true
+        },
+        "ajv": {
+          "version": "4.11.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "co": "4.6.0",
+            "json-stable-stringify": "1.0.1"
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "bundled": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "delegates": "1.0.0",
+            "readable-stream": "2.2.9"
+          }
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "bundled": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "tweetnacl": "0.14.5"
+          }
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "bundled": true,
+          "requires": {
+            "inherits": "2.0.3"
+          }
+        },
+        "boom": {
+          "version": "2.10.1",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "brace-expansion": {
+          "version": "1.1.7",
+          "bundled": true,
+          "requires": {
+            "balanced-match": "0.4.2",
+            "concat-map": "0.0.1"
+          }
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "caseless": {
+          "version": "0.12.0",
+          "bundled": true,
+          "optional": true
+        },
+        "co": {
+          "version": "4.6.0",
+          "bundled": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "bundled": true,
+          "requires": {
+            "delayed-stream": "1.0.0"
+          }
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "bundled": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "bundled": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1"
+          }
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.6.8",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "deep-extend": {
+          "version": "0.4.2",
+          "bundled": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "detect-libc": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "extend": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "bundled": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asynckit": "0.4.0",
+            "combined-stream": "1.0.5",
+            "mime-types": "2.1.15"
+          }
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "fstream": {
+          "version": "1.0.11",
+          "bundled": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "inherits": "2.0.3",
+            "mkdirp": "0.5.1",
+            "rimraf": "2.6.1"
+          }
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "fstream": "1.0.11",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4"
+          }
+        },
+        "gauge": {
+          "version": "2.7.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aproba": "1.1.1",
+            "console-control-strings": "1.1.0",
+            "has-unicode": "2.0.1",
+            "object-assign": "4.1.1",
+            "signal-exit": "3.0.2",
+            "string-width": "1.0.2",
+            "strip-ansi": "3.0.1",
+            "wide-align": "1.1.2"
+          }
+        },
+        "getpass": {
+          "version": "0.1.7",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.2",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "1.0.0",
+            "inflight": "1.0.6",
+            "inherits": "2.0.3",
+            "minimatch": "3.0.4",
+            "once": "1.4.0",
+            "path-is-absolute": "1.0.1"
+          }
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "bundled": true
+        },
+        "har-schema": {
+          "version": "1.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "4.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "ajv": "4.11.8",
+            "har-schema": "1.0.5"
+          }
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "bundled": true,
+          "requires": {
+            "boom": "2.10.1",
+            "cryptiles": "2.0.5",
+            "hoek": "2.16.3",
+            "sntp": "1.0.9"
+          }
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "bundled": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "0.2.0",
+            "jsprim": "1.4.0",
+            "sshpk": "1.13.0"
+          }
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "bundled": true,
+          "requires": {
+            "once": "1.4.0",
+            "wrappy": "1.0.2"
+          }
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "bundled": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "bundled": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "bundled": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "bundled": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "bundled": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsbn": "0.1.1"
+          }
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "bundled": true,
+          "optional": true
+        },
+        "json-stable-stringify": {
+          "version": "1.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "jsonify": "0.0.0"
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "jsonify": {
+          "version": "0.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.0.2",
+            "json-schema": "0.2.3",
+            "verror": "1.3.6"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "mime-db": {
+          "version": "1.27.0",
+          "bundled": true
+        },
+        "mime-types": {
+          "version": "2.1.15",
+          "bundled": true,
+          "requires": {
+            "mime-db": "1.27.0"
+          }
+        },
+        "minimatch": {
+          "version": "3.0.4",
+          "bundled": true,
+          "requires": {
+            "brace-expansion": "1.1.7"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "bundled": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "bundled": true,
+          "requires": {
+            "minimist": "0.0.8"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.39",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "detect-libc": "1.0.2",
+            "hawk": "3.1.3",
+            "mkdirp": "0.5.1",
+            "nopt": "4.0.1",
+            "npmlog": "4.1.0",
+            "rc": "1.2.1",
+            "request": "2.81.0",
+            "rimraf": "2.6.1",
+            "semver": "5.3.0",
+            "tar": "2.2.1",
+            "tar-pack": "3.4.0"
+          }
+        },
+        "nopt": {
+          "version": "4.0.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "abbrev": "1.1.0",
+            "osenv": "0.1.4"
+          }
+        },
+        "npmlog": {
+          "version": "4.1.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "1.1.4",
+            "console-control-strings": "1.1.0",
+            "gauge": "2.7.4",
+            "set-blocking": "2.0.0"
+          }
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "bundled": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "bundled": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "bundled": true,
+          "requires": {
+            "wrappy": "1.0.2"
+          }
+        },
+        "os-homedir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "os-tmpdir": {
+          "version": "1.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "osenv": {
+          "version": "0.1.4",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "os-homedir": "1.0.2",
+            "os-tmpdir": "1.0.2"
+          }
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "bundled": true
+        },
+        "performance-now": {
+          "version": "0.2.0",
+          "bundled": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "bundled": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "bundled": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.4.0",
+          "bundled": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.2.1",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "deep-extend": "0.4.2",
+            "ini": "1.3.4",
+            "minimist": "1.2.0",
+            "strip-json-comments": "2.0.1"
+          },
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.9",
+          "bundled": true,
+          "requires": {
+            "buffer-shims": "1.0.0",
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "1.0.0",
+            "process-nextick-args": "1.0.7",
+            "string_decoder": "1.0.1",
+            "util-deprecate": "1.0.2"
+          }
+        },
+        "request": {
+          "version": "2.81.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "aws-sign2": "0.6.0",
+            "aws4": "1.6.0",
+            "caseless": "0.12.0",
+            "combined-stream": "1.0.5",
+            "extend": "3.0.1",
+            "forever-agent": "0.6.1",
+            "form-data": "2.1.4",
+            "har-validator": "4.2.1",
+            "hawk": "3.1.3",
+            "http-signature": "1.1.1",
+            "is-typedarray": "1.0.0",
+            "isstream": "0.1.2",
+            "json-stringify-safe": "5.0.1",
+            "mime-types": "2.1.15",
+            "oauth-sign": "0.8.2",
+            "performance-now": "0.2.0",
+            "qs": "6.4.0",
+            "safe-buffer": "5.0.1",
+            "stringstream": "0.0.5",
+            "tough-cookie": "2.3.2",
+            "tunnel-agent": "0.6.0",
+            "uuid": "3.0.1"
+          }
+        },
+        "rimraf": {
+          "version": "2.6.1",
+          "bundled": true,
+          "requires": {
+            "glob": "7.1.2"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.0.1",
+          "bundled": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "bundled": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "bundled": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "bundled": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "bundled": true,
+          "requires": {
+            "hoek": "2.16.3"
+          }
+        },
+        "sshpk": {
+          "version": "1.13.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "asn1": "0.2.3",
+            "assert-plus": "1.0.0",
+            "bcrypt-pbkdf": "1.0.1",
+            "dashdash": "1.14.1",
+            "ecc-jsbn": "0.1.1",
+            "getpass": "0.1.7",
+            "jodid25519": "1.0.2",
+            "jsbn": "0.1.1",
+            "tweetnacl": "0.14.5"
+          },
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "bundled": true,
+              "optional": true
+            }
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "bundled": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "bundled": true,
+          "requires": {
+            "ansi-regex": "2.1.1"
+          }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "bundled": true,
+          "requires": {
+            "block-stream": "0.0.9",
+            "fstream": "1.0.11",
+            "inherits": "2.0.3"
+          }
+        },
+        "tar-pack": {
+          "version": "3.4.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "debug": "2.6.8",
+            "fstream": "1.0.11",
+            "fstream-ignore": "1.0.5",
+            "once": "1.4.0",
+            "readable-stream": "2.2.9",
+            "rimraf": "2.6.1",
+            "tar": "2.2.1",
+            "uid-number": "0.0.6"
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
+        "tunnel-agent": {
+          "version": "0.6.0",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "bundled": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "bundled": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "bundled": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "bundled": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "extsprintf": "1.0.2"
+          }
+        },
+        "wide-align": {
+          "version": "1.1.2",
+          "bundled": true,
+          "optional": true,
+          "requires": {
+            "string-width": "1.0.2"
+          }
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "bundled": true
+        }
+      }
+    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
@@ -6340,6 +7159,15 @@
         "pretty-format": "21.2.1"
       }
     },
+    "jest-styled-components": {
+      "version": "4.10.0",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-4.10.0.tgz",
+      "integrity": "sha512-bYAZoaX6VgcE4ITGBo+QKPKuYwWlNBEvLjpac9VwhPFPbCxGb22kwviOimqZ0Lw4EXOy7tRKPDQDgjqfvcZOSQ==",
+      "dev": true,
+      "requires": {
+        "css": "2.2.1"
+      }
+    },
     "jest-util": {
       "version": "21.2.1",
       "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-21.2.1.tgz",
@@ -7663,6 +8491,12 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
+      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -10997,6 +11831,12 @@
       "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
       "dev": true
     },
+    "resolve-url": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
+      "integrity": "sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=",
+      "dev": true
+    },
     "restore-cursor": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
@@ -11103,6 +11943,7 @@
         "anymatch": "1.3.2",
         "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
+        "fsevents": "1.1.3",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
         "walker": "1.0.7",
@@ -11308,6 +12149,18 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
     },
+    "source-map-resolve": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.3.1.tgz",
+      "integrity": "sha1-YQ9hIqRFuN1RU1oqcbeD38Ekh2E=",
+      "dev": true,
+      "requires": {
+        "atob": "1.1.3",
+        "resolve-url": "0.2.1",
+        "source-map-url": "0.3.0",
+        "urix": "0.1.0"
+      }
+    },
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
@@ -11324,6 +12177,12 @@
           "dev": true
         }
       }
+    },
+    "source-map-url": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.3.0.tgz",
+      "integrity": "sha1-fsrxO1e80J2opAxdJp2zN5nUqvk=",
+      "dev": true
     },
     "spdx-correct": {
       "version": "1.0.2",
@@ -12033,6 +12892,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.3.tgz",
       "integrity": "sha1-9rRQHC7EzdJrp4vnIilh3ndiFZg="
+    },
+    "urix": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
+      "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=",
+      "dev": true
     },
     "url": {
       "version": "0.11.0",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "husky": "^0.14.3",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^21.2.1",
+    "jest-styled-components": "^4.10.0",
     "less": "^2.7.3",
     "less-loader": "^4.0.5",
     "lint-staged": "^5.0.0",

--- a/src/components/Alert/__tests__/Alert.test.jsx
+++ b/src/components/Alert/__tests__/Alert.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Alert } from 'index';
 

--- a/src/components/Alert/__tests__/__snapshots__/Alert.test.jsx.snap
+++ b/src/components/Alert/__tests__/__snapshots__/Alert.test.jsx.snap
@@ -1,11 +1,91 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  border-radius: 0;
+}
+
+.c1.alert-info {
+  color: #00948d;
+  background-color: #b9eeeb;
+  border-color: #b9eeeb;
+}
+
+.c1.alert-info a {
+  color: #00948d;
+  text-decoration: underline;
+}
+
+.c1.alert-info a:hover,
+.c1.alert-info a:focus,
+.c1.alert-info a:active {
+  color: #00948d;
+  text-decoration: none;
+}
+
+.c1.alert-success {
+  color: #348538;
+  background-color: #c8e6c9;
+  border-color: #c8e6c9;
+}
+
+.c1.alert-success a {
+  color: #348538;
+  text-decoration: underline;
+}
+
+.c1.alert-success a:hover,
+.c1.alert-success a:focus,
+.c1.alert-success a:active {
+  color: #348538;
+  text-decoration: none;
+}
+
+.c1.alert-warning {
+  color: #de8c00;
+  background-color: #fff2ce;
+  border-color: #fff2ce;
+}
+
+.c1.alert-warning a {
+  color: #de8c00;
+  text-decoration: underline;
+}
+
+.c1.alert-warning a:hover,
+.c1.alert-warning a:focus,
+.c1.alert-warning a:active {
+  color: #de8c00;
+  text-decoration: none;
+}
+
+.c1.alert-danger {
+  color: #c92d2d;
+  background-color: #ffcdd2;
+  border-color: #ffcdd2;
+}
+
+.c1.alert-danger a {
+  color: #c92d2d;
+  text-decoration: underline;
+}
+
+.c1.alert-danger a:hover,
+.c1.alert-danger a:focus,
+.c1.alert-danger a:active {
+  color: #c92d2d;
+  text-decoration: none;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="alert alert-info sc-EHOje gjPsaZ"
+    className="alert alert-info c1"
   >
     <div />
   </div>

--- a/src/components/Button/__tests__/Button.test.jsx
+++ b/src/components/Button/__tests__/Button.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Button } from 'index';
 

--- a/src/components/Button/__tests__/__snapshots__/Button.test.jsx.snap
+++ b/src/components/Button/__tests__/__snapshots__/Button.test.jsx.snap
@@ -1,11 +1,240 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  border-style: solid;
+  border-width: 2px;
+  border-radius: 4px;
+}
+
+.c1.btn-default {
+  font-weight: 500;
+  color: #3b3f45;
+  background-color: #ffffff;
+  border-color: #c9cacc;
+}
+
+.c1.btn-default:hover {
+  color: #3b3f45;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn-default:focus {
+  color: #3b3f45;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn-default:active,
+.c1.btn-default .active {
+  color: #3b3f45;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn-primary {
+  font-weight: 500;
+  color: #ffffff;
+  background-color: #2196f3;
+  border-color: #186fc5;
+}
+
+.c1.btn-primary:hover {
+  color: #ffffff;
+  background-color: #71bcf7;
+  border-color: #2196f3;
+}
+
+.c1.btn-primary:focus {
+  color: #ffffff;
+  background-color: #71bcf7;
+  border-color: #2196f3;
+}
+
+.c1.btn-primary:active,
+.c1.btn-primary .active {
+  color: #ffffff;
+  background-color: #71bcf7;
+  border-color: #2196f3;
+}
+
+.c1.btn-info {
+  font-weight: 500;
+  color: #000a0a;
+  background-color: #00c2b8;
+  border-color: #00948d;
+}
+
+.c1.btn-info:hover {
+  color: #000a0a;
+  background-color: #5cd7d1;
+  border-color: #00c2b8;
+}
+
+.c1.btn-info:focus {
+  color: #000a0a;
+  background-color: #5cd7d1;
+  border-color: #00c2b8;
+}
+
+.c1.btn-info:active,
+.c1.btn-info .active {
+  color: #000a0a;
+  background-color: #5cd7d1;
+  border-color: #00c2b8;
+}
+
+.c1.btn-success {
+  font-weight: 500;
+  color: #ffffff;
+  background-color: #4caf50;
+  border-color: #348538;
+}
+
+.c1.btn-success:hover {
+  color: #ffffff;
+  background-color: #7cc47f;
+  border-color: #4caf50;
+}
+
+.c1.btn-success:focus {
+  color: #ffffff;
+  background-color: #7cc47f;
+  border-color: #4caf50;
+}
+
+.c1.btn-success:active,
+.c1.btn-success .active {
+  color: #ffffff;
+  background-color: #7cc47f;
+  border-color: #4caf50;
+}
+
+.c1.btn-warning {
+  font-weight: 500;
+  color: #543500;
+  background-color: #ffa700;
+  border-color: #de8c00;
+}
+
+.c1.btn-warning:hover {
+  color: #543500;
+  background-color: #ffd659;
+  border-color: #ffa700;
+}
+
+.c1.btn-warning:focus {
+  color: #543500;
+  background-color: #ffd659;
+  border-color: #ffa700;
+}
+
+.c1.btn-warning:active,
+.c1.btn-warning .active {
+  color: #543500;
+  background-color: #ffd659;
+  border-color: #ffa700;
+}
+
+.c1.btn-danger {
+  font-weight: 500;
+  color: #ffffff;
+  background-color: #f44336;
+  border-color: #c92d2d;
+}
+
+.c1.btn-danger:hover {
+  color: #ffffff;
+  background-color: #f8877f;
+  border-color: #f44336;
+}
+
+.c1.btn-danger:focus {
+  color: #ffffff;
+  background-color: #f8877f;
+  border-color: #f44336;
+}
+
+.c1.btn-danger:active,
+.c1.btn-danger .active {
+  color: #ffffff;
+  background-color: #f8877f;
+  border-color: #f44336;
+}
+
+.c1.btn-link {
+  font-weight: 400;
+  color: #2196f3;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.c1.btn-link:hover {
+  color: #2196f3;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.c1.btn-link:focus {
+  color: #2196f3;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.c1.btn-link:active,
+.c1.btn-link .active {
+  color: #2196f3;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.c1.btn-xs {
+  font-size: 1.2rem;
+  line-height: 2.1rem;
+  padding: 0 1.4rem;
+}
+
+.c1.btn-sm {
+  line-height: 3rem;
+  padding: 0 1.6rem;
+}
+
+.c1.btn-md {
+  line-height: 3.8rem;
+  padding: 0 2rem;
+}
+
+.c1.btn-lg {
+  line-height: 4.5rem;
+  padding: 0 2.4rem;
+}
+
+.c1.shape-round.btn-xs {
+  border-radius: 1.25rem;
+}
+
+.c1.shape-round.btn-sm {
+  border-radius: 1.7rem;
+}
+
+.c1.shape-round.btn-md {
+  border-radius: 2.1rem;
+}
+
+.c1.shape-round.btn-lg {
+  border-radius: 2.45rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <button
-    className="btn shape-round btn-default btn-md sc-bZQynM hMdykY"
+    className="btn shape-round btn-default btn-md c1"
     disabled={false}
     type="button"
   >
@@ -15,11 +244,240 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots on an anchor typed Button Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  border-style: solid;
+  border-width: 2px;
+  border-radius: 4px;
+}
+
+.c1.btn-default {
+  font-weight: 500;
+  color: #3b3f45;
+  background-color: #ffffff;
+  border-color: #c9cacc;
+}
+
+.c1.btn-default:hover {
+  color: #3b3f45;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn-default:focus {
+  color: #3b3f45;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn-default:active,
+.c1.btn-default .active {
+  color: #3b3f45;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn-primary {
+  font-weight: 500;
+  color: #ffffff;
+  background-color: #2196f3;
+  border-color: #186fc5;
+}
+
+.c1.btn-primary:hover {
+  color: #ffffff;
+  background-color: #71bcf7;
+  border-color: #2196f3;
+}
+
+.c1.btn-primary:focus {
+  color: #ffffff;
+  background-color: #71bcf7;
+  border-color: #2196f3;
+}
+
+.c1.btn-primary:active,
+.c1.btn-primary .active {
+  color: #ffffff;
+  background-color: #71bcf7;
+  border-color: #2196f3;
+}
+
+.c1.btn-info {
+  font-weight: 500;
+  color: #000a0a;
+  background-color: #00c2b8;
+  border-color: #00948d;
+}
+
+.c1.btn-info:hover {
+  color: #000a0a;
+  background-color: #5cd7d1;
+  border-color: #00c2b8;
+}
+
+.c1.btn-info:focus {
+  color: #000a0a;
+  background-color: #5cd7d1;
+  border-color: #00c2b8;
+}
+
+.c1.btn-info:active,
+.c1.btn-info .active {
+  color: #000a0a;
+  background-color: #5cd7d1;
+  border-color: #00c2b8;
+}
+
+.c1.btn-success {
+  font-weight: 500;
+  color: #ffffff;
+  background-color: #4caf50;
+  border-color: #348538;
+}
+
+.c1.btn-success:hover {
+  color: #ffffff;
+  background-color: #7cc47f;
+  border-color: #4caf50;
+}
+
+.c1.btn-success:focus {
+  color: #ffffff;
+  background-color: #7cc47f;
+  border-color: #4caf50;
+}
+
+.c1.btn-success:active,
+.c1.btn-success .active {
+  color: #ffffff;
+  background-color: #7cc47f;
+  border-color: #4caf50;
+}
+
+.c1.btn-warning {
+  font-weight: 500;
+  color: #543500;
+  background-color: #ffa700;
+  border-color: #de8c00;
+}
+
+.c1.btn-warning:hover {
+  color: #543500;
+  background-color: #ffd659;
+  border-color: #ffa700;
+}
+
+.c1.btn-warning:focus {
+  color: #543500;
+  background-color: #ffd659;
+  border-color: #ffa700;
+}
+
+.c1.btn-warning:active,
+.c1.btn-warning .active {
+  color: #543500;
+  background-color: #ffd659;
+  border-color: #ffa700;
+}
+
+.c1.btn-danger {
+  font-weight: 500;
+  color: #ffffff;
+  background-color: #f44336;
+  border-color: #c92d2d;
+}
+
+.c1.btn-danger:hover {
+  color: #ffffff;
+  background-color: #f8877f;
+  border-color: #f44336;
+}
+
+.c1.btn-danger:focus {
+  color: #ffffff;
+  background-color: #f8877f;
+  border-color: #f44336;
+}
+
+.c1.btn-danger:active,
+.c1.btn-danger .active {
+  color: #ffffff;
+  background-color: #f8877f;
+  border-color: #f44336;
+}
+
+.c1.btn-link {
+  font-weight: 400;
+  color: #2196f3;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.c1.btn-link:hover {
+  color: #2196f3;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.c1.btn-link:focus {
+  color: #2196f3;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.c1.btn-link:active,
+.c1.btn-link .active {
+  color: #2196f3;
+  background-color: transparent;
+  border-color: transparent;
+}
+
+.c1.btn-xs {
+  font-size: 1.2rem;
+  line-height: 2.1rem;
+  padding: 0 1.4rem;
+}
+
+.c1.btn-sm {
+  line-height: 3rem;
+  padding: 0 1.6rem;
+}
+
+.c1.btn-md {
+  line-height: 3.8rem;
+  padding: 0 2rem;
+}
+
+.c1.btn-lg {
+  line-height: 4.5rem;
+  padding: 0 2.4rem;
+}
+
+.c1.shape-round.btn-xs {
+  border-radius: 1.25rem;
+}
+
+.c1.shape-round.btn-sm {
+  border-radius: 1.7rem;
+}
+
+.c1.shape-round.btn-md {
+  border-radius: 2.1rem;
+}
+
+.c1.shape-round.btn-lg {
+  border-radius: 2.45rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <a
-    className="btn shape-round btn-default btn-md sc-gzVnrw iTLIgl"
+    className="btn shape-round btn-default btn-md c1"
     disabled={false}
     role="button"
   >

--- a/src/components/Form/Checkbox.jsx
+++ b/src/components/Form/Checkbox.jsx
@@ -68,6 +68,7 @@ const Checkbox = ({ id, label, className, ...props }) => {
 
 Checkbox.propTypes = {
   id: PropTypes.string.isRequired,
+  value: PropTypes.string.isRequired,
   label: PropTypes.string,
   disabled: PropTypes.bool,
   className: PropTypes.string

--- a/src/components/Form/__tests__/Checkbox.test.js
+++ b/src/components/Form/__tests__/Checkbox.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import Form from '../index';
 

--- a/src/components/Form/__tests__/Checkbox.test.js
+++ b/src/components/Form/__tests__/Checkbox.test.js
@@ -4,5 +4,5 @@ import Form from '../index';
 
 describe('When using snapshots', () => {
   it('Checkbox should render with an element children', () =>
-    snapshotWithElementChildren(Form.Checkbox, { id: '1' }));
+    snapshotWithElementChildren(Form.Checkbox, { id: '1', value: 'myValue' }));
 });

--- a/src/components/Form/__tests__/Form.test.js
+++ b/src/components/Form/__tests__/Form.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import Form from '../index';
 

--- a/src/components/Form/__tests__/Group.test.js
+++ b/src/components/Form/__tests__/Group.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import Form from '../index';
 

--- a/src/components/Form/__tests__/Input.test.js
+++ b/src/components/Form/__tests__/Input.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import Form from '../index';
 

--- a/src/components/Form/__tests__/Label.test.js
+++ b/src/components/Form/__tests__/Label.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import Form from '../index';
 

--- a/src/components/Form/__tests__/Select.test.js
+++ b/src/components/Form/__tests__/Select.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import Form from '../index';
 

--- a/src/components/Form/__tests__/Textarea.test.js
+++ b/src/components/Form/__tests__/Textarea.test.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import Form from '../index';
 

--- a/src/components/Form/__tests__/__snapshots__/Checkbox.test.js.snap
+++ b/src/components/Form/__tests__/__snapshots__/Checkbox.test.js.snap
@@ -13,6 +13,7 @@ exports[`When using snapshots Checkbox should render with an element children 1`
       disabled={false}
       id="1"
       type="checkbox"
+      value="myValue"
     >
       <div />
     </input>

--- a/src/components/Form/__tests__/__snapshots__/Checkbox.test.js.snap
+++ b/src/components/Form/__tests__/__snapshots__/Checkbox.test.js.snap
@@ -1,15 +1,78 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Checkbox should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c3 {
+  color: #101113;
+  background-color: #ffffff;
+  margin-bottom: 0.6rem;
+  font-size: 1.7rem;
+  font-weight: 400;
+}
+
+.c1 {
+  position: relative;
+  color: #101113;
+  background-color: #ffffff;
+  border-color: #101113;
+}
+
+.c2 {
+  opacity: 0;
+  width: 0;
+  height: 0;
+  margin: 0;
+}
+
+.c2 + label {
+  font-size: 1.7rem;
+  line-height: 1.7rem;
+  font-weight: 400;
+  padding-left: 2.5rem;
+  cursor: pointer;
+}
+
+.c2 + label:before,
+.c2 + label:after {
+  display: inline-block;
+  position: absolute;
+  left: 0;
+  top: 0.4rem;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+  border-color: #b7b9bb;
+  content: '';
+  width: 1.7rem;
+  height: 1.7rem;
+  -webkit-transition: border 0.15s ease-in-out,color 0.15s ease-in-out;
+  transition: border 0.15s ease-in-out,color 0.15s ease-in-out;
+}
+
+.c2:checked + label:after {
+  padding-left: 0.5px;
+  content: '\\f00c';
+  font-family: FontAwesome;
+  font-size: 1.4rem;
+}
+
+.c2:disabled + label,
+.c2:disabled + label:after {
+  opacity: 0.3;
+  cursor: not-allowed;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="sc-gzVnrw irbVPN"
+    className="c1"
   >
     <input
       checked={undefined}
-      className="sc-htoDjs hePhMK"
+      className="c2"
       disabled={false}
       id="1"
       type="checkbox"
@@ -18,7 +81,7 @@ exports[`When using snapshots Checkbox should render with an element children 1`
       <div />
     </input>
     <label
-      className="control-label sc-htpNat fXbItB"
+      className="control-label c3"
       htmlFor="1"
     >
       

--- a/src/components/Form/__tests__/__snapshots__/Form.test.js.snap
+++ b/src/components/Form/__tests__/__snapshots__/Form.test.js.snap
@@ -1,8 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Form should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <form>
     <div />

--- a/src/components/Form/__tests__/__snapshots__/Group.test.js.snap
+++ b/src/components/Form/__tests__/__snapshots__/Group.test.js.snap
@@ -1,11 +1,79 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots FormGroup should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  margin-bottom: 4rem;
+}
+
+.c1.has-info .control-label {
+  color: #00948d;
+}
+
+.c1.has-info .Select-control,
+.c1.has-info .form-control {
+  background-color: #ffffff;
+  border-color: #00c2b8;
+}
+
+.c1.has-info .help-block {
+  background-color: #00c2b8;
+  color: #000a0a;
+}
+
+.c1.has-success .control-label {
+  color: #348538;
+}
+
+.c1.has-success .Select-control,
+.c1.has-success .form-control {
+  background-color: #ffffff;
+  border-color: #4caf50;
+}
+
+.c1.has-success .help-block {
+  background-color: #4caf50;
+  color: #ffffff;
+}
+
+.c1.has-warning .control-label {
+  color: #de8c00;
+}
+
+.c1.has-warning .Select-control,
+.c1.has-warning .form-control {
+  background-color: #ffffff;
+  border-color: #ffa700;
+}
+
+.c1.has-warning .help-block {
+  background-color: #ffa700;
+  color: #543500;
+}
+
+.c1.has-error .control-label {
+  color: #c92d2d;
+}
+
+.c1.has-error .Select-control,
+.c1.has-error .form-control {
+  background-color: #ffffff;
+  border-color: #f44336;
+}
+
+.c1.has-error .help-block {
+  background-color: #f44336;
+  color: #ffffff;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="form-group sc-bwzfXH jtiegF"
+    className="form-group c1"
   >
     <div />
   </div>

--- a/src/components/Form/__tests__/__snapshots__/Input.test.js.snap
+++ b/src/components/Form/__tests__/__snapshots__/Input.test.js.snap
@@ -1,12 +1,33 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Input should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  opacity: 0.8;
+  background-color: #ffffff;
+  border-color: #c9cacc;
+  border-width: 2px;
+  border-radius: 0;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+}
+
+.c1:focus,
+.c1.form-control:focus {
+  opacity: 1;
+  background-color: #ffffff;
+  border-color: #2196f3;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div>
     <input
-      className="form-control sc-ifAKCX gvQyyI"
+      className="form-control c1"
       disabled={false}
       type="text"
     >
@@ -18,12 +39,33 @@ exports[`When using snapshots Input should render with an element children 1`] =
 `;
 
 exports[`When using snapshots Input with Hint should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  opacity: 0.8;
+  background-color: #ffffff;
+  border-color: #c9cacc;
+  border-width: 2px;
+  border-radius: 0;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+}
+
+.c1:focus,
+.c1.form-control:focus {
+  opacity: 1;
+  background-color: #ffffff;
+  border-color: #2196f3;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div>
     <input
-      className="form-control sc-ifAKCX gvQyyI"
+      className="form-control c1"
       disabled={false}
       type="text"
     >

--- a/src/components/Form/__tests__/__snapshots__/Label.test.js.snap
+++ b/src/components/Form/__tests__/__snapshots__/Label.test.js.snap
@@ -1,11 +1,23 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Label should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  color: #101113;
+  background-color: #ffffff;
+  margin-bottom: 0.6rem;
+  font-size: 1.7rem;
+  font-weight: 400;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <label
-    className="control-label sc-htpNat fXbItB"
+    className="control-label c1"
     htmlFor=""
   >
     <div />

--- a/src/components/Form/__tests__/__snapshots__/Select.test.js.snap
+++ b/src/components/Form/__tests__/__snapshots__/Select.test.js.snap
@@ -1,12 +1,66 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Select should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 .Select-control {
+  opacity: 0.8;
+  background-color: #ffffff;
+  border-color: #c9cacc;
+  border-width: 2px;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+.c1.is-focused .Select-control,
+.c1.is-focused:not(.is-open) > .Select-control {
+  opacity: 1;
+  background-color: #ffffff;
+  border-color: #2196f3;
+  box-shadow: none;
+}
+
+.c1 .Select-placeholder {
+  padding-left: 1.2rem;
+  line-height: 3.8rem;
+}
+
+.c1.Select--single .Select-value {
+  padding-left: 1.2rem;
+}
+
+.c1.Select--single .Select-value .Select-value-label {
+  line-height: 3.8rem;
+}
+
+.c1 .Select-input > input {
+  padding: 0.1rem;
+  line-height: 3.2rem;
+}
+
+.c1 .Select-menu-outer {
+  margin-top: 0;
+  border-top-width: 0;
+}
+
+.c1 .VirtualizedSelectOption {
+  cursor: default;
+  padding: 0.5rem 1rem;
+}
+
+.c1 .VirtualizedSelectFocusedOption {
+  color: #ffffff;
+  background-color: #2196f3;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div>
     <div
-      className="Select sc-bZQynM feWkwg Select--single is-clearable is-searchable"
+      className="Select c1 Select--single is-clearable is-searchable"
       style={undefined}
     >
       <div

--- a/src/components/Form/__tests__/__snapshots__/Textarea.test.js.snap
+++ b/src/components/Form/__tests__/__snapshots__/Textarea.test.js.snap
@@ -1,12 +1,34 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots TextArea should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  opacity: 0.8;
+  resize: vertical;
+  background-color: #ffffff;
+  border-color: #c9cacc;
+  border-width: 2px;
+  border-radius: 0;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+}
+
+.c1:focus,
+.c1.form-control:focus {
+  opacity: 1;
+  background-color: #ffffff;
+  border-color: #2196f3;
+  box-shadow: inset 0 1px 1px rgba(0,0,0,0.075);
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div>
     <textarea
-      className="form-control sc-EHOje ecZjZY"
+      className="form-control c1"
       disabled={false}
       rows={6}
     >

--- a/src/components/Loader/__tests__/Loader.test.jsx
+++ b/src/components/Loader/__tests__/Loader.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Loader } from 'index';
 

--- a/src/components/Loader/__tests__/__snapshots__/Loader.test.jsx.snap
+++ b/src/components/Loader/__tests__/__snapshots__/Loader.test.jsx.snap
@@ -1,15 +1,58 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c2 {
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto;
+  border-width: 3px;
+  border-style: solid;
+  border-color: #707377;
+  border-radius: 50%;
+  border-left-color: transparent;
+  border-bottom-color: transparent;
+  border-right-color: transparent;
+  -webkit-animation: iVXCSc 650ms infinite linear;
+  animation: iVXCSc 650ms infinite linear;
+}
+
+.c1 {
+  text-align: center;
+}
+
+.c1.centered {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="sc-bxivhb gIwMIC"
+    className="c1"
   >
     <div>
       <div
-        className="sc-htpNat jHFNJI"
+        className="c2"
       />
       
     </div>
@@ -18,18 +61,66 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots with a label prop Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c2 {
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto;
+  border-width: 3px;
+  border-style: solid;
+  border-color: #707377;
+  border-radius: 50%;
+  border-left-color: transparent;
+  border-bottom-color: transparent;
+  border-right-color: transparent;
+  -webkit-animation: iVXCSc 650ms infinite linear;
+  animation: iVXCSc 650ms infinite linear;
+}
+
+.c1 {
+  text-align: center;
+}
+
+.c1.centered {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c3 {
+  color: #707377;
+  margin-top: 1.5rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="sc-bxivhb gIwMIC"
+    className="c1"
   >
     <div>
       <div
-        className="sc-htpNat jHFNJI"
+        className="c2"
       />
       <div
-        className="sc-ifAKCX hlQgNG"
+        className="c3"
       >
         This is a label
       </div>

--- a/src/components/Modal/__tests__/Modal.test.jsx
+++ b/src/components/Modal/__tests__/Modal.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import 'jest-styled-components';
 import { shallow } from 'enzyme';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Modal } from 'index';

--- a/src/components/Modal/__tests__/__snapshots__/Modal.test.jsx.snap
+++ b/src/components/Modal/__tests__/__snapshots__/Modal.test.jsx.snap
@@ -1,11 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  z-index: 1000;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 3rem;
+  background: rgba(255,255,255,0.95);
+  color: #101113;
+  overflow-y: auto;
+  opacity: 0;
+  -webkit-transition: opacity 300ms ease-in-out;
+  transition: opacity 300ms ease-in-out;
+  position: absolute;
+}
+
+.c1.scroll-content {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow-y: none;
+}
+
+.c1.scroll-content .header {
+  margin-bottom: 2rem;
+}
+
+.c1 .content {
+  padding: 2rem;
+}
+
+.c1.scroll-content .content {
+  overflow-y: auto;
+  margin: 0;
+  border-color: #dbdcdd;
+  border-style: solid;
+  border-width: 1px 0 1px 0;
+}
+
+.c1.scroll-content .content::after {
+  content: '';
+  margin-top: 2rem;
+  display: block;
+}
+
+.c1 .content.loading {
+  display: none;
+}
+
+.c1.scroll-content .footer {
+  margin-top: 2rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <aside
-    className="container-root sc-iAyFgw klaKDQ"
+    className="container-root c1"
     style={undefined}
   >
     
@@ -20,11 +81,116 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots with loader Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c3 {
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto;
+  border-width: 3px;
+  border-style: solid;
+  border-color: #707377;
+  border-radius: 50%;
+  border-left-color: transparent;
+  border-bottom-color: transparent;
+  border-right-color: transparent;
+  -webkit-animation: iVXCSc 650ms infinite linear;
+  animation: iVXCSc 650ms infinite linear;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c2.centered {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c4 {
+  color: #707377;
+  margin-top: 1.5rem;
+}
+
+.c1 {
+  z-index: 1000;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 3rem;
+  background: rgba(255,255,255,0.95);
+  color: #101113;
+  overflow-y: auto;
+  opacity: 0;
+  -webkit-transition: opacity 300ms ease-in-out;
+  transition: opacity 300ms ease-in-out;
+  position: absolute;
+}
+
+.c1.scroll-content {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow-y: none;
+}
+
+.c1.scroll-content .header {
+  margin-bottom: 2rem;
+}
+
+.c1 .content {
+  padding: 2rem;
+}
+
+.c1.scroll-content .content {
+  overflow-y: auto;
+  margin: 0;
+  border-color: #dbdcdd;
+  border-style: solid;
+  border-width: 1px 0 1px 0;
+}
+
+.c1.scroll-content .content::after {
+  content: '';
+  margin-top: 2rem;
+  display: block;
+}
+
+.c1 .content.loading {
+  display: none;
+}
+
+.c1.scroll-content .footer {
+  margin-top: 2rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <aside
-    className="container-root sc-iAyFgw klaKDQ"
+    className="container-root c1"
     style={undefined}
   >
     
@@ -34,14 +200,14 @@ exports[`When using snapshots with loader Should render with an element children
       <div />
     </div>
     <div
-      className="centered sc-bxivhb gIwMIC"
+      className="centered c2"
     >
       <div>
         <div
-          className="sc-htpNat jHFNJI"
+          className="c3"
         />
         <div
-          className="sc-ifAKCX hlQgNG"
+          className="c4"
         >
           loading
         </div>
@@ -52,18 +218,91 @@ exports[`When using snapshots with loader Should render with an element children
 `;
 
 exports[`When using snapshots with title, header and footer Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c2 {
+  margin: -3rem 0 5rem;
+}
+
+.c2.in-header {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0 0 0 2rem;
+  line-height: 5rem;
+}
+
+.c1 {
+  z-index: 1000;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 3rem;
+  background: rgba(255,255,255,0.95);
+  color: #101113;
+  overflow-y: auto;
+  opacity: 0;
+  -webkit-transition: opacity 300ms ease-in-out;
+  transition: opacity 300ms ease-in-out;
+  position: absolute;
+}
+
+.c1.scroll-content {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow-y: none;
+}
+
+.c1.scroll-content .header {
+  margin-bottom: 2rem;
+}
+
+.c1 .content {
+  padding: 2rem;
+}
+
+.c1.scroll-content .content {
+  overflow-y: auto;
+  margin: 0;
+  border-color: #dbdcdd;
+  border-style: solid;
+  border-width: 1px 0 1px 0;
+}
+
+.c1.scroll-content .content::after {
+  content: '';
+  margin-top: 2rem;
+  display: block;
+}
+
+.c1 .content.loading {
+  display: none;
+}
+
+.c1.scroll-content .footer {
+  margin-top: 2rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <aside
-    className="container-root sc-iAyFgw klaKDQ"
+    className="container-root c1"
     style={undefined}
   >
     <header
       className="header"
     >
       <h2
-        className="sidebar-title in-header sc-jzJRlG jKSUDG"
+        className="sidebar-title in-header c2"
       >
         title
       </h2>

--- a/src/components/Notification/__tests__/Group.test.jsx
+++ b/src/components/Notification/__tests__/Group.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Notification } from 'index';
 

--- a/src/components/Notification/__tests__/Notification.test.jsx
+++ b/src/components/Notification/__tests__/Notification.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Notification } from 'index';
 

--- a/src/components/Notification/__tests__/__snapshots__/Group.test.jsx.snap
+++ b/src/components/Notification/__tests__/__snapshots__/Group.test.jsx.snap
@@ -1,11 +1,106 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  position: absolute;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  width: 50rem;
+}
+
+.c1:empty {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.c1.position-top-right {
+  top: 0;
+  right: 0;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.position-top-left {
+  top: 0;
+  left: 0;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c1.position-bottom-right {
+  bottom: 0;
+  right: 0;
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+}
+
+.c1.position-bottom-left {
+  bottom: 0;
+  left: 0;
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+}
+
+.c1.position-top {
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 50%;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.c1.position-bottom {
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 50%;
+  margin-left: auto;
+  margin-right: auto;
+  -webkit-flex-direction: column-reverse;
+  -ms-flex-direction: column-reverse;
+  flex-direction: column-reverse;
+}
+
+.c1 .notif-item {
+  position: relative;
+  width: 100%;
+}
+
+@media (max-width:50rem) {
+  .c1 {
+    width: 100%;
+  }
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <aside
-    className="position-top-right direction-horizontal sc-cvbbAY htIyDs"
+    className="position-top-right direction-horizontal c1"
   >
     <div
       className="notif-item"

--- a/src/components/Notification/__tests__/__snapshots__/Notification.test.jsx.snap
+++ b/src/components/Notification/__tests__/__snapshots__/Notification.test.jsx.snap
@@ -1,15 +1,214 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  position: absolute;
+  width: 50rem;
+  max-width: 100%;
+  -webkit-transition: -webkit-transform 500ms ease-in-out;
+  -webkit-transition: transform 500ms ease-in-out;
+  transition: transform 500ms ease-in-out;
+}
+
+.c1.position-top-right {
+  top: 0;
+  right: 0;
+  -webkit-transform: translate(100%,0);
+  -ms-transform: translate(100%,0);
+  transform: translate(100%,0);
+}
+
+.c1.position-top-right.direction-vertical {
+  -webkit-transform: translate(0,-100%);
+  -ms-transform: translate(0,-100%);
+  transform: translate(0,-100%);
+}
+
+.c1.position-top-left {
+  top: 0;
+  left: 0;
+  -webkit-transform: translate(-100%,0);
+  -ms-transform: translate(-100%,0);
+  transform: translate(-100%,0);
+}
+
+.c1.position-top-left.direction-vertical {
+  -webkit-transform: translate(0,-100%);
+  -ms-transform: translate(0,-100%);
+  transform: translate(0,-100%);
+}
+
+.c1.position-bottom-left {
+  bottom: 0;
+  left: 0;
+  -webkit-transform: translate(-100%,0);
+  -ms-transform: translate(-100%,0);
+  transform: translate(-100%,0);
+}
+
+.c1.position-bottom-left.direction-vertical {
+  -webkit-transform: translate(0,100%);
+  -ms-transform: translate(0,100%);
+  transform: translate(0,100%);
+}
+
+.c1.position-bottom-right {
+  bottom: 0;
+  right: 0;
+  -webkit-transform: translate(100%,0);
+  -ms-transform: translate(100%,0);
+  transform: translate(100%,0);
+}
+
+.c1.position-bottom-right.direction-vertical {
+  -webkit-transform: translate(0,100%);
+  -ms-transform: translate(0,100%);
+  transform: translate(0,100%);
+}
+
+.c1.position-top {
+  top: 0;
+  left: 0;
+  right: 0;
+  width: 50%;
+  margin-left: auto;
+  margin-right: auto;
+  -webkit-transform: translate(100%,0);
+  -ms-transform: translate(100%,0);
+  transform: translate(100%,0);
+}
+
+.c1.position-top.direction-vertical {
+  -webkit-transform: translate(0,-100%);
+  -ms-transform: translate(0,-100%);
+  transform: translate(0,-100%);
+}
+
+.c1.position-bottom {
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 50%;
+  margin-left: auto;
+  margin-right: auto;
+  -webkit-transform: translate(100%,0);
+  -ms-transform: translate(100%,0);
+  transform: translate(100%,0);
+}
+
+.c1.position-bottom.direction-vertical {
+  -webkit-transform: translate(0,100%);
+  -ms-transform: translate(0,100%);
+  transform: translate(0,100%);
+}
+
+.c2 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  z-index: 1000;
+  width: 100%;
+  height: 4rem;
+  margin: 0.2rem 0;
+  padding: 0 0.5rem;
+  overflow-y: auto;
+  font-size: 1.3rem;
+  color: #00948d;
+  background: #ffffff;
+  border-color: #b9eeeb;
+  border-style: solid;
+  border-width: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+  -webkit-transition: height 500ms ease-in-out,margin 500ms ease-in-out;
+  transition: height 500ms ease-in-out,margin 500ms ease-in-out;
+}
+
+.c2.position-top-right,
+.c2.position-bottom-right {
+  border-left-width: 4px;
+}
+
+.c2.position-top-left,
+.c2.position-bottom-left {
+  border-right-width: 4px;
+}
+
+.c2.position-top {
+  border-bottom-width: 4px;
+}
+
+.c2.position-bottom {
+  border-top-width: 4px;
+}
+
+.c2 .icon {
+  display: inline-block;
+  color: #b9eeeb;
+  background: transparent;
+  border-width: 0;
+  height: 100%;
+  margin-right: 1rem;
+  line-height: 4rem;
+}
+
+.c2 .close-btn {
+  display: inline-block;
+  color: #dbdcdd;
+  background: transparent;
+  border-width: 0;
+  height: 100%;
+  padding: 0 1rem;
+  margin-left: 0.5rem;
+}
+
+.c2 .close-btn:hover {
+  color: #707377;
+}
+
+.c2 .content {
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  -webkit-flex: 2 1 auto;
+  -ms-flex: 2 1 auto;
+  flex: 2 1 auto;
+  height: 100%;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+}
+
+.c2 .content * {
+  margin-left: 0.5rem;
+}
+
+@media (max-width:50rem) {
+  .c1 {
+    width: 100%;
+    font-size: 1.2rem;
+  }
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="position-top-right direction-horizontal sc-hSdWYo bHvuiu"
+    className="position-top-right direction-horizontal c1"
     style={undefined}
   >
     <aside
-      className="position-top-right direction-horizontal sc-eHgmQL iSHCLI"
+      className="position-top-right direction-horizontal c2"
       direction="horizontal"
       id={1}
       onMouseEnter={[Function]}

--- a/src/components/Section/__tests__/Section.test.jsx
+++ b/src/components/Section/__tests__/Section.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Section } from 'index';
 

--- a/src/components/Section/__tests__/__snapshots__/Section.test.jsx.snap
+++ b/src/components/Section/__tests__/__snapshots__/Section.test.jsx.snap
@@ -1,11 +1,35 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  color: #101113;
+  background-color: #ffffff;
+}
+
+.c1 > * {
+  opacity: 1;
+}
+
+.c1.app-canvas {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <section
-    className="sc-bwzfXH bWibny"
+    className="c1"
   >
     <div />
   </section>
@@ -13,11 +37,35 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots with the dimmed prop Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  color: #101113;
+  background-color: #ffffff;
+}
+
+.c1 > * {
+  opacity: 0.2;
+}
+
+.c1.app-canvas {
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  overflow: hidden;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <section
-    className="sc-bwzfXH cbGbWf"
+    className="c1"
   >
     <div />
   </section>

--- a/src/components/Sidebar/__tests__/Footer.test.jsx
+++ b/src/components/Sidebar/__tests__/Footer.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Sidebar } from 'index';
 

--- a/src/components/Sidebar/__tests__/Header.test.jsx
+++ b/src/components/Sidebar/__tests__/Header.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Sidebar } from 'index';
 

--- a/src/components/Sidebar/__tests__/Nav.test.jsx
+++ b/src/components/Sidebar/__tests__/Nav.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Sidebar } from 'index';
 

--- a/src/components/Sidebar/__tests__/Sidebar.test.jsx
+++ b/src/components/Sidebar/__tests__/Sidebar.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Sidebar } from 'index';
 

--- a/src/components/Sidebar/__tests__/Title.test.jsx
+++ b/src/components/Sidebar/__tests__/Title.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Sidebar } from 'index';
 

--- a/src/components/Sidebar/__tests__/__snapshots__/Footer.test.jsx.snap
+++ b/src/components/Sidebar/__tests__/__snapshots__/Footer.test.jsx.snap
@@ -1,11 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  padding: 2rem 2rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="sidebar-footer sc-chPdSV bVKvVf"
+    className="sidebar-footer c1"
   >
     <div />
   </div>
@@ -13,11 +21,19 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots Should render with className and other props 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  padding: 2rem 2rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="my-class sidebar-footer sc-chPdSV bVKvVf"
+    className="my-class sidebar-footer c1"
   >
     <div />
   </div>
@@ -25,11 +41,19 @@ exports[`When using snapshots Should render with className and other props 1`] =
 `;
 
 exports[`When using snapshots Should render with other props 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  padding: 2rem 2rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="sidebar-footer sc-chPdSV bVKvVf"
+    className="sidebar-footer c1"
   >
     <div />
   </div>
@@ -37,11 +61,19 @@ exports[`When using snapshots Should render with other props 1`] = `
 `;
 
 exports[`When using snapshots Should render with the className prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  padding: 2rem 2rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="my-class sidebar-footer sc-chPdSV bVKvVf"
+    className="my-class sidebar-footer c1"
   >
     <div />
   </div>

--- a/src/components/Sidebar/__tests__/__snapshots__/Header.test.jsx.snap
+++ b/src/components/Sidebar/__tests__/__snapshots__/Header.test.jsx.snap
@@ -1,11 +1,19 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  padding: 1.5rem 2rem 0;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="sidebar-header sc-kAzzGY fGsbhJ"
+    className="sidebar-header c1"
   >
     <div />
   </div>
@@ -13,11 +21,19 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots Should render with className and other props 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  padding: 1.5rem 2rem 0;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="my-class sidebar-header sc-kAzzGY fGsbhJ"
+    className="my-class sidebar-header c1"
   >
     <div />
   </div>
@@ -25,11 +41,19 @@ exports[`When using snapshots Should render with className and other props 1`] =
 `;
 
 exports[`When using snapshots Should render with other props 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  padding: 1.5rem 2rem 0;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="sidebar-header sc-kAzzGY fGsbhJ"
+    className="sidebar-header c1"
   >
     <div />
   </div>
@@ -37,11 +61,19 @@ exports[`When using snapshots Should render with other props 1`] = `
 `;
 
 exports[`When using snapshots Should render with the className prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  padding: 1.5rem 2rem 0;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="my-class sidebar-header sc-kAzzGY fGsbhJ"
+    className="my-class sidebar-header c1"
   >
     <div />
   </div>

--- a/src/components/Sidebar/__tests__/__snapshots__/Nav.test.jsx.snap
+++ b/src/components/Sidebar/__tests__/__snapshots__/Nav.test.jsx.snap
@@ -1,11 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  margin: 2rem 0;
+}
+
+.c1 ul {
+  text-align: center;
+  list-style: none;
+  margin: 0 0 4rem;
+  padding: 0;
+}
+
+.c1 a {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  display: block;
+  margin: 1rem 0;
+  padding: 1.4rem 2rem;
+  border-radius: 4px;
+  background-color: #eceeef;
+  color: #101113;
+  font-size: 1.8rem;
+  line-height: 2rem;
+  font-weight: 500;
+}
+
+.c1 a:hover,
+.c1 a:active,
+.c1 a:focus {
+  text-decoration: none;
+  color: #101113;
+  background-color: #dbdcdd;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <nav
-    className="sc-kgoBCf iAgIpA"
+    className="c1"
   >
     <div />
   </nav>

--- a/src/components/Sidebar/__tests__/__snapshots__/Sidebar.test.jsx.snap
+++ b/src/components/Sidebar/__tests__/__snapshots__/Sidebar.test.jsx.snap
@@ -34,11 +34,159 @@ exports[`When using snapshots Should render with a some props and children 1`] =
 `;
 
 exports[`When using snapshots Should render with a title 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c2 {
+  margin: -3rem 0 5rem;
+}
+
+.c2.in-header {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0 0 0 2rem;
+  line-height: 5rem;
+}
+
+.c1 {
+  z-index: 1000;
+  top: 0;
+  max-width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  -webkit-transition: all 0.25s ease-out;
+  transition: all 0.25s ease-out;
+  color: #101113;
+  background: #ffffff;
+  border-color: #dbdcdd;
+  border-style: solid;
+  border-width: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.scroll-content {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow-y: none;
+}
+
+.c1.container-parent {
+  position: absolute;
+}
+
+.c1.container-root {
+  position: fixed;
+}
+
+.c1.xs {
+  width: 15rem;
+}
+
+.c1.sm {
+  width: 25rem;
+}
+
+.c1.md {
+  width: 40rem;
+}
+
+.c1.lg {
+  width: 60rem;
+}
+
+.c1.maximized {
+  width: 100%;
+}
+
+.c1.left {
+  left: 0;
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+  border-right-width: 4px;
+}
+
+.c1.right {
+  right: 0;
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+  border-left-width: 4px;
+}
+
+.c1.left.maximized,
+.c1.right.maximized {
+  border-width: 0;
+}
+
+.c1 .back-btn,
+.c1 .close-btn {
+  color: #dbdcdd;
+  background: transparent;
+  border-width: 0;
+  width: 5rem;
+  height: 5rem;
+  padding: 0;
+}
+
+.c1 .back-btn:hover,
+.c1 .close-btn:hover {
+  color: #707377;
+}
+
+.c1 .back-btn {
+  float: left;
+  margin-right: 0.5rem;
+}
+
+.c1 .close-btn {
+  float: right;
+  margin-left: 0.5rem;
+}
+
+.c1.scroll-content .header {
+  margin-bottom: 2rem;
+}
+
+.c1 .content {
+  margin-top: 3rem;
+  padding: 2rem;
+}
+
+.c1.scroll-content .content {
+  overflow-y: auto;
+  margin: 0;
+  border-color: #dbdcdd;
+  border-style: solid;
+  border-width: 1px 0 1px 0;
+}
+
+.c1.scroll-content .content::after {
+  content: '';
+  margin-top: 2rem;
+  display: block;
+}
+
+.c1 .content.loading {
+  display: none;
+}
+
+.c1.scroll-content .footer {
+  margin-top: 2rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <aside
-    className="left md opened container-parent sc-cSHVUG clsess"
+    className="left md opened container-parent c1"
     style={undefined}
   >
     <header
@@ -54,7 +202,7 @@ exports[`When using snapshots Should render with a title 1`] = `
         />
       </button>
       <h2
-        className="sidebar-title in-header sc-jzJRlG jKSUDG"
+        className="sidebar-title in-header c2"
       >
         A title
       </h2>
@@ -74,11 +222,147 @@ exports[`When using snapshots Should render with a title 1`] = `
 `;
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  z-index: 1000;
+  top: 0;
+  max-width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  -webkit-transition: all 0.25s ease-out;
+  transition: all 0.25s ease-out;
+  color: #101113;
+  background: #ffffff;
+  border-color: #dbdcdd;
+  border-style: solid;
+  border-width: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.scroll-content {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow-y: none;
+}
+
+.c1.container-parent {
+  position: absolute;
+}
+
+.c1.container-root {
+  position: fixed;
+}
+
+.c1.xs {
+  width: 15rem;
+}
+
+.c1.sm {
+  width: 25rem;
+}
+
+.c1.md {
+  width: 40rem;
+}
+
+.c1.lg {
+  width: 60rem;
+}
+
+.c1.maximized {
+  width: 100%;
+}
+
+.c1.left {
+  left: 0;
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+  border-right-width: 4px;
+}
+
+.c1.right {
+  right: 0;
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+  border-left-width: 4px;
+}
+
+.c1.left.maximized,
+.c1.right.maximized {
+  border-width: 0;
+}
+
+.c1 .back-btn,
+.c1 .close-btn {
+  color: #dbdcdd;
+  background: transparent;
+  border-width: 0;
+  width: 5rem;
+  height: 5rem;
+  padding: 0;
+}
+
+.c1 .back-btn:hover,
+.c1 .close-btn:hover {
+  color: #707377;
+}
+
+.c1 .back-btn {
+  float: left;
+  margin-right: 0.5rem;
+}
+
+.c1 .close-btn {
+  float: right;
+  margin-left: 0.5rem;
+}
+
+.c1.scroll-content .header {
+  margin-bottom: 2rem;
+}
+
+.c1 .content {
+  margin-top: 3rem;
+  padding: 2rem;
+}
+
+.c1.scroll-content .content {
+  overflow-y: auto;
+  margin: 0;
+  border-color: #dbdcdd;
+  border-style: solid;
+  border-width: 1px 0 1px 0;
+}
+
+.c1.scroll-content .content::after {
+  content: '';
+  margin-top: 2rem;
+  display: block;
+}
+
+.c1 .content.loading {
+  display: none;
+}
+
+.c1.scroll-content .footer {
+  margin-top: 2rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <aside
-    className="left md opened container-parent sc-cSHVUG clsess"
+    className="left md opened container-parent c1"
     style={undefined}
   >
     <header
@@ -110,11 +394,186 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots Should render with the loading prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c3 {
+  width: 4rem;
+  height: 4rem;
+  margin: 0 auto;
+  border-width: 3px;
+  border-style: solid;
+  border-color: #707377;
+  border-radius: 50%;
+  border-left-color: transparent;
+  border-bottom-color: transparent;
+  border-right-color: transparent;
+  -webkit-animation: iVXCSc 650ms infinite linear;
+  animation: iVXCSc 650ms infinite linear;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c2.centered {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1 {
+  z-index: 1000;
+  top: 0;
+  max-width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  -webkit-transition: all 0.25s ease-out;
+  transition: all 0.25s ease-out;
+  color: #101113;
+  background: #ffffff;
+  border-color: #dbdcdd;
+  border-style: solid;
+  border-width: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.scroll-content {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+  overflow-y: none;
+}
+
+.c1.container-parent {
+  position: absolute;
+}
+
+.c1.container-root {
+  position: fixed;
+}
+
+.c1.xs {
+  width: 15rem;
+}
+
+.c1.sm {
+  width: 25rem;
+}
+
+.c1.md {
+  width: 40rem;
+}
+
+.c1.lg {
+  width: 60rem;
+}
+
+.c1.maximized {
+  width: 100%;
+}
+
+.c1.left {
+  left: 0;
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+  border-right-width: 4px;
+}
+
+.c1.right {
+  right: 0;
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+  border-left-width: 4px;
+}
+
+.c1.left.maximized,
+.c1.right.maximized {
+  border-width: 0;
+}
+
+.c1 .back-btn,
+.c1 .close-btn {
+  color: #dbdcdd;
+  background: transparent;
+  border-width: 0;
+  width: 5rem;
+  height: 5rem;
+  padding: 0;
+}
+
+.c1 .back-btn:hover,
+.c1 .close-btn:hover {
+  color: #707377;
+}
+
+.c1 .back-btn {
+  float: left;
+  margin-right: 0.5rem;
+}
+
+.c1 .close-btn {
+  float: right;
+  margin-left: 0.5rem;
+}
+
+.c1.scroll-content .header {
+  margin-bottom: 2rem;
+}
+
+.c1 .content {
+  margin-top: 3rem;
+  padding: 2rem;
+}
+
+.c1.scroll-content .content {
+  overflow-y: auto;
+  margin: 0;
+  border-color: #dbdcdd;
+  border-style: solid;
+  border-width: 1px 0 1px 0;
+}
+
+.c1.scroll-content .content::after {
+  content: '';
+  margin-top: 2rem;
+  display: block;
+}
+
+.c1 .content.loading {
+  display: none;
+}
+
+.c1.scroll-content .footer {
+  margin-top: 2rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <aside
-    className="left md opened container-parent sc-cSHVUG clsess"
+    className="left md opened container-parent c1"
     style={undefined}
   >
     <header
@@ -140,11 +599,11 @@ exports[`When using snapshots Should render with the loading prop 1`] = `
       <div />
     </div>
     <div
-      className="centered sc-bxivhb gIwMIC"
+      className="centered c2"
     >
       <div>
         <div
-          className="sc-htpNat jHFNJI"
+          className="c3"
         />
         
       </div>

--- a/src/components/Sidebar/__tests__/__snapshots__/Title.test.jsx.snap
+++ b/src/components/Sidebar/__tests__/__snapshots__/Title.test.jsx.snap
@@ -1,11 +1,27 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  margin: -3rem 0 5rem;
+}
+
+.c1.in-header {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0 0 0 2rem;
+  line-height: 5rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <h2
-    className="sidebar-title sc-jzJRlG jKSUDG"
+    className="sidebar-title c1"
   >
     <div />
   </h2>
@@ -13,11 +29,27 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots Should render with className and other props 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  margin: -3rem 0 5rem;
+}
+
+.c1.in-header {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0 0 0 2rem;
+  line-height: 5rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <h2
-    className="my-class sidebar-title sc-jzJRlG jKSUDG"
+    className="my-class sidebar-title c1"
   >
     <div />
   </h2>
@@ -25,11 +57,27 @@ exports[`When using snapshots Should render with className and other props 1`] =
 `;
 
 exports[`When using snapshots Should render with other props 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  margin: -3rem 0 5rem;
+}
+
+.c1.in-header {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0 0 0 2rem;
+  line-height: 5rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <h2
-    className="sidebar-title sc-jzJRlG jKSUDG"
+    className="sidebar-title c1"
   >
     <div />
   </h2>
@@ -37,11 +85,27 @@ exports[`When using snapshots Should render with other props 1`] = `
 `;
 
 exports[`When using snapshots Should render with the className prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  margin: -3rem 0 5rem;
+}
+
+.c1.in-header {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  margin: 0 0 0 2rem;
+  line-height: 5rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <h2
-    className="my-class sidebar-title sc-jzJRlG jKSUDG"
+    className="my-class sidebar-title c1"
   >
     <div />
   </h2>

--- a/src/components/Titlebar/__tests__/Titlebar.test.jsx
+++ b/src/components/Titlebar/__tests__/Titlebar.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import 'jest-styled-components';
 import { shallow } from 'enzyme';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Titlebar } from 'index';

--- a/src/components/Titlebar/__tests__/__snapshots__/Titlebar.test.jsx.snap
+++ b/src/components/Titlebar/__tests__/__snapshots__/Titlebar.test.jsx.snap
@@ -1,11 +1,80 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  z-index: 1000;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  left: 0;
+  right: 0;
+  font-weight: 500;
+  color: #101113;
+  border-color: #dbdcdd;
+  border-style: solid;
+  border-width: 0;
+  background: #ffffff;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+  text-align: center;
+}
+
+.c1.container-parent {
+  position: absolute;
+}
+
+.c1.container-root {
+  position: fixed;
+}
+
+.c1.position-top {
+  top: 0;
+  border-bottom-width: 1px;
+}
+
+.c1.position-bottom {
+  bottom: 0;
+  border-top-width: 1px;
+}
+
+.c1.xs {
+  height: 3rem;
+  font-size: 1.4rem;
+  line-height: 3rem;
+}
+
+.c1.sm {
+  height: 3.5rem;
+  font-size: 1.6rem;
+  line-height: 3.5rem;
+}
+
+.c1.md {
+  height: 4rem;
+  font-size: 1.8rem;
+  line-height: 4rem;
+}
+
+.c1.lg {
+  height: 4.5rem;
+  font-size: 1.9rem;
+  line-height: 4.5rem;
+}
+
+.c1.maximized {
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  border-width: 0;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <header
-    className="md position-top container-parent sc-kEYyzF dQQSQE"
+    className="md position-top container-parent c1"
   >
     <div />
   </header>
@@ -13,11 +82,80 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots with the maximized prop Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  z-index: 1000;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  left: 0;
+  right: 0;
+  font-weight: 500;
+  color: #101113;
+  border-color: #dbdcdd;
+  border-style: solid;
+  border-width: 0;
+  background: #ffffff;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+  text-align: center;
+}
+
+.c1.container-parent {
+  position: absolute;
+}
+
+.c1.container-root {
+  position: fixed;
+}
+
+.c1.position-top {
+  top: 0;
+  border-bottom-width: 1px;
+}
+
+.c1.position-bottom {
+  bottom: 0;
+  border-top-width: 1px;
+}
+
+.c1.xs {
+  height: 3rem;
+  font-size: 1.4rem;
+  line-height: 3rem;
+}
+
+.c1.sm {
+  height: 3.5rem;
+  font-size: 1.6rem;
+  line-height: 3.5rem;
+}
+
+.c1.md {
+  height: 4rem;
+  font-size: 1.8rem;
+  line-height: 4rem;
+}
+
+.c1.lg {
+  height: 4.5rem;
+  font-size: 1.9rem;
+  line-height: 4.5rem;
+}
+
+.c1.maximized {
+  height: 100%;
+  top: 0;
+  bottom: 0;
+  border-width: 0;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <header
-    className="md position-top container-parent maximized sc-kEYyzF dQQSQE"
+    className="md position-top container-parent maximized c1"
   >
     <div />
   </header>

--- a/src/components/Toolbar/__tests__/Collapse.test.jsx
+++ b/src/components/Toolbar/__tests__/Collapse.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import 'jest-styled-components';
 import { shallow } from 'enzyme';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Toolbar } from 'index';

--- a/src/components/Toolbar/__tests__/Group.test.jsx
+++ b/src/components/Toolbar/__tests__/Group.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 // import { shallow } from 'enzyme';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Toolbar } from 'index';

--- a/src/components/Toolbar/__tests__/Item.test.jsx
+++ b/src/components/Toolbar/__tests__/Item.test.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import 'jest-styled-components';
 // import { shallow } from 'enzyme';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Toolbar } from 'index';

--- a/src/components/Toolbar/__tests__/Toolbar.test.jsx
+++ b/src/components/Toolbar/__tests__/Toolbar.test.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import 'jest-styled-components';
 import { shallow } from 'enzyme';
 import { snapshotWithElementChildren } from 'helpers/tests';
 import { Toolbar } from 'index';

--- a/src/components/Toolbar/__tests__/__snapshots__/Collapse.test.jsx.snap
+++ b/src/components/Toolbar/__tests__/__snapshots__/Collapse.test.jsx.snap
@@ -1,14 +1,270 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c2,
+.c2.btn {
+  position: relative;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  pointer-events: all;
+  color: #101113;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  background: #ffffff;
+  font-weight: 500;
+  padding: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c2.shape-square {
+  border-radius: 4px;
+}
+
+.c2.shape-round {
+  border-radius: 50%;
+}
+
+.c2.xs {
+  width: 2.4rem;
+  height: 2.4rem;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.c2.xs .fa {
+  font-size: 1.2rem;
+}
+
+.c2.sm {
+  width: 3rem;
+  height: 3rem;
+  line-height: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.c2.sm .fa {
+  font-size: 1.4rem;
+}
+
+.c2.md {
+  width: 4rem;
+  height: 4rem;
+  line-height: 1.6rem;
+  font-size: 1.4rem;
+}
+
+.c2.md .fa {
+  font-size: 1.6rem;
+}
+
+.c2.lg {
+  width: 5rem;
+  height: 5rem;
+  line-height: 1.7rem;
+  font-size: 1.8rem;
+}
+
+.c2.lg .fa {
+  font-size: 2rem;
+}
+
+.c2.in-group {
+  width: calc(4rem - (2px * 2));
+  height: calc(4rem - (2px * 2));
+  border-width: 0;
+  box-shadow: none;
+}
+
+.c2.btn:hover {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:hover.in-group {
+  border-color: #eceeef;
+}
+
+.c2.btn:focus {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:focus.in-group {
+  border-color: #eceeef;
+}
+
+.c2.btn:active,
+.c2.btn.active {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:active.in-group,
+.c2.btn.active.in-group {
+  border-color: #eceeef;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c3.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3.direction-column.position-left-center > *,
+.c3.direction-column.position-left-top > *,
+.c3.direction-column.position-center-top > *,
+.c3.direction-column.position-right-top > *,
+.c3.direction-column.position-right-center > * {
+  margin-top: .8rem;
+}
+
+.c3.direction-column.position-left-bottom > *,
+.c3.direction-column.position-center-bottom > *,
+.c3.direction-column.position-right-bottom > * {
+  margin-bottom: .8rem;
+}
+
+.c3.direction-row.position-center-top > *,
+.c3.direction-row.position-left-top > *,
+.c3.direction-row.position-left-center > *,
+.c3.direction-row.position-left-bottom > *,
+.c3.direction-row.position-center-bottom > * {
+  margin-left: .8rem;
+}
+
+.c3.direction-row.position-right-top > *,
+.c3.direction-row.position-right-center > *,
+.c3.direction-row.position-right-bottom > * {
+  margin-right: .8rem;
+}
+
+.c3.direction-column.position-left-top,
+.c3.direction-column.position-left-center,
+.c3.direction-column.position-left-bottom {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c3.direction-column.position-center-top {
+  -webkit-transform: translate(0,-200%);
+  -ms-transform: translate(0,-200%);
+  transform: translate(0,-200%);
+}
+
+.c3.direction-column.position-center-bottom {
+  -webkit-transform: translate(0,200%);
+  -ms-transform: translate(0,200%);
+  transform: translate(0,200%);
+}
+
+.c3.direction-column.position-right-top,
+.c3.direction-column.position-right-center,
+.c3.direction-column.position-right-bottom {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c3.direction-row.position-left-top,
+.c3.direction-row.position-center-top,
+.c3.direction-row.position-right-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c3.direction-row.position-left-center {
+  -webkit-transform: translate(-200%,0);
+  -ms-transform: translate(-200%,0);
+  transform: translate(-200%,0);
+}
+
+.c3.direction-row.position-right-center {
+  -webkit-transform: translate(200%,0);
+  -ms-transform: translate(200%,0);
+  transform: translate(200%,0);
+}
+
+.c3.direction-row.position-left-bottom,
+.c3.direction-row.position-center-bottom,
+.c3.direction-row.position-right-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c3.direction-column.position-left-top.opened,
+.c3.direction-row.position-left-top.opened,
+.c3.direction-column.position-center-top.opened,
+.c3.direction-row.position-center-top.opened,
+.c3.direction-column.position-right-top.opened,
+.c3.direction-row.position-right-top.opened,
+.c3.direction-column.position-right-center.opened,
+.c3.direction-row.position-right-center.opened,
+.c3.direction-column.position-right-bottom.opened,
+.c3.direction-row.position-right-bottom.opened,
+.c3.direction-column.position-center-bottom.opened,
+.c3.direction-row.position-center-bottom.opened,
+.c3.direction-column.position-left-bottom.opened,
+.c3.direction-row.position-left-bottom.opened,
+.c3.direction-column.position-left-center.opened,
+.c3.direction-row.position-left-center.opened {
+  -webkit-transform: translate(0,0);
+  -ms-transform: translate(0,0);
+  transform: translate(0,0);
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="position-left-top direction-column sc-eNQAEJ kJIalf"
+    className="position-left-top direction-column c1"
   >
     <button
-      className="md shape-round btn sc-kpOJdX deOJdy"
+      className="md shape-round btn c2"
       onClick={[Function]}
       size="md"
     >
@@ -19,7 +275,7 @@ exports[`When using snapshots Should render with an element children 1`] = `
       />
     </button>
     <div
-      className="position-left-top direction-column sc-hMqMXs frWmYS"
+      className="position-left-top direction-column c3"
       onClick={null}
     >
       <div
@@ -31,14 +287,270 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots Should render with the direction and position prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c3,
+.c3.btn {
+  position: relative;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  pointer-events: all;
+  color: #101113;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  background: #ffffff;
+  font-weight: 500;
+  padding: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c3.shape-square {
+  border-radius: 4px;
+}
+
+.c3.shape-round {
+  border-radius: 50%;
+}
+
+.c3.xs {
+  width: 2.4rem;
+  height: 2.4rem;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.c3.xs .fa {
+  font-size: 1.2rem;
+}
+
+.c3.sm {
+  width: 3rem;
+  height: 3rem;
+  line-height: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.c3.sm .fa {
+  font-size: 1.4rem;
+}
+
+.c3.md {
+  width: 4rem;
+  height: 4rem;
+  line-height: 1.6rem;
+  font-size: 1.4rem;
+}
+
+.c3.md .fa {
+  font-size: 1.6rem;
+}
+
+.c3.lg {
+  width: 5rem;
+  height: 5rem;
+  line-height: 1.7rem;
+  font-size: 1.8rem;
+}
+
+.c3.lg .fa {
+  font-size: 2rem;
+}
+
+.c3.in-group {
+  width: calc(4rem - (2px * 2));
+  height: calc(4rem - (2px * 2));
+  border-width: 0;
+  box-shadow: none;
+}
+
+.c3.btn:hover {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c3.btn:hover.in-group {
+  border-color: #eceeef;
+}
+
+.c3.btn:focus {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c3.btn:focus.in-group {
+  border-color: #eceeef;
+}
+
+.c3.btn:active,
+.c3.btn.active {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c3.btn:active.in-group,
+.c3.btn.active.in-group {
+  border-color: #eceeef;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2 {
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c2.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c2.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c2.direction-column.position-left-center > *,
+.c2.direction-column.position-left-top > *,
+.c2.direction-column.position-center-top > *,
+.c2.direction-column.position-right-top > *,
+.c2.direction-column.position-right-center > * {
+  margin-top: .8rem;
+}
+
+.c2.direction-column.position-left-bottom > *,
+.c2.direction-column.position-center-bottom > *,
+.c2.direction-column.position-right-bottom > * {
+  margin-bottom: .8rem;
+}
+
+.c2.direction-row.position-center-top > *,
+.c2.direction-row.position-left-top > *,
+.c2.direction-row.position-left-center > *,
+.c2.direction-row.position-left-bottom > *,
+.c2.direction-row.position-center-bottom > * {
+  margin-left: .8rem;
+}
+
+.c2.direction-row.position-right-top > *,
+.c2.direction-row.position-right-center > *,
+.c2.direction-row.position-right-bottom > * {
+  margin-right: .8rem;
+}
+
+.c2.direction-column.position-left-top,
+.c2.direction-column.position-left-center,
+.c2.direction-column.position-left-bottom {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c2.direction-column.position-center-top {
+  -webkit-transform: translate(0,-200%);
+  -ms-transform: translate(0,-200%);
+  transform: translate(0,-200%);
+}
+
+.c2.direction-column.position-center-bottom {
+  -webkit-transform: translate(0,200%);
+  -ms-transform: translate(0,200%);
+  transform: translate(0,200%);
+}
+
+.c2.direction-column.position-right-top,
+.c2.direction-column.position-right-center,
+.c2.direction-column.position-right-bottom {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c2.direction-row.position-left-top,
+.c2.direction-row.position-center-top,
+.c2.direction-row.position-right-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c2.direction-row.position-left-center {
+  -webkit-transform: translate(-200%,0);
+  -ms-transform: translate(-200%,0);
+  transform: translate(-200%,0);
+}
+
+.c2.direction-row.position-right-center {
+  -webkit-transform: translate(200%,0);
+  -ms-transform: translate(200%,0);
+  transform: translate(200%,0);
+}
+
+.c2.direction-row.position-left-bottom,
+.c2.direction-row.position-center-bottom,
+.c2.direction-row.position-right-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c2.direction-column.position-left-top.opened,
+.c2.direction-row.position-left-top.opened,
+.c2.direction-column.position-center-top.opened,
+.c2.direction-row.position-center-top.opened,
+.c2.direction-column.position-right-top.opened,
+.c2.direction-row.position-right-top.opened,
+.c2.direction-column.position-right-center.opened,
+.c2.direction-row.position-right-center.opened,
+.c2.direction-column.position-right-bottom.opened,
+.c2.direction-row.position-right-bottom.opened,
+.c2.direction-column.position-center-bottom.opened,
+.c2.direction-row.position-center-bottom.opened,
+.c2.direction-column.position-left-bottom.opened,
+.c2.direction-row.position-left-bottom.opened,
+.c2.direction-column.position-left-center.opened,
+.c2.direction-row.position-left-center.opened {
+  -webkit-transform: translate(0,0);
+  -ms-transform: translate(0,0);
+  transform: translate(0,0);
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="position-right-top direction-row sc-eNQAEJ kJIalf"
+    className="position-right-top direction-row c1"
   >
     <div
-      className="position-right-top direction-row sc-hMqMXs frWmYS"
+      className="position-right-top direction-row c2"
       onClick={null}
     >
       <div
@@ -46,7 +558,7 @@ exports[`When using snapshots Should render with the direction and position prop
       />
     </div>
     <button
-      className="md shape-round btn sc-kpOJdX deOJdy"
+      className="md shape-round btn c3"
       onClick={[Function]}
       size="md"
     >
@@ -61,14 +573,270 @@ exports[`When using snapshots Should render with the direction and position prop
 `;
 
 exports[`When using snapshots Should render with the direction prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c2,
+.c2.btn {
+  position: relative;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  pointer-events: all;
+  color: #101113;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  background: #ffffff;
+  font-weight: 500;
+  padding: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c2.shape-square {
+  border-radius: 4px;
+}
+
+.c2.shape-round {
+  border-radius: 50%;
+}
+
+.c2.xs {
+  width: 2.4rem;
+  height: 2.4rem;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.c2.xs .fa {
+  font-size: 1.2rem;
+}
+
+.c2.sm {
+  width: 3rem;
+  height: 3rem;
+  line-height: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.c2.sm .fa {
+  font-size: 1.4rem;
+}
+
+.c2.md {
+  width: 4rem;
+  height: 4rem;
+  line-height: 1.6rem;
+  font-size: 1.4rem;
+}
+
+.c2.md .fa {
+  font-size: 1.6rem;
+}
+
+.c2.lg {
+  width: 5rem;
+  height: 5rem;
+  line-height: 1.7rem;
+  font-size: 1.8rem;
+}
+
+.c2.lg .fa {
+  font-size: 2rem;
+}
+
+.c2.in-group {
+  width: calc(4rem - (2px * 2));
+  height: calc(4rem - (2px * 2));
+  border-width: 0;
+  box-shadow: none;
+}
+
+.c2.btn:hover {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:hover.in-group {
+  border-color: #eceeef;
+}
+
+.c2.btn:focus {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:focus.in-group {
+  border-color: #eceeef;
+}
+
+.c2.btn:active,
+.c2.btn.active {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:active.in-group,
+.c2.btn.active.in-group {
+  border-color: #eceeef;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c3.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3.direction-column.position-left-center > *,
+.c3.direction-column.position-left-top > *,
+.c3.direction-column.position-center-top > *,
+.c3.direction-column.position-right-top > *,
+.c3.direction-column.position-right-center > * {
+  margin-top: .8rem;
+}
+
+.c3.direction-column.position-left-bottom > *,
+.c3.direction-column.position-center-bottom > *,
+.c3.direction-column.position-right-bottom > * {
+  margin-bottom: .8rem;
+}
+
+.c3.direction-row.position-center-top > *,
+.c3.direction-row.position-left-top > *,
+.c3.direction-row.position-left-center > *,
+.c3.direction-row.position-left-bottom > *,
+.c3.direction-row.position-center-bottom > * {
+  margin-left: .8rem;
+}
+
+.c3.direction-row.position-right-top > *,
+.c3.direction-row.position-right-center > *,
+.c3.direction-row.position-right-bottom > * {
+  margin-right: .8rem;
+}
+
+.c3.direction-column.position-left-top,
+.c3.direction-column.position-left-center,
+.c3.direction-column.position-left-bottom {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c3.direction-column.position-center-top {
+  -webkit-transform: translate(0,-200%);
+  -ms-transform: translate(0,-200%);
+  transform: translate(0,-200%);
+}
+
+.c3.direction-column.position-center-bottom {
+  -webkit-transform: translate(0,200%);
+  -ms-transform: translate(0,200%);
+  transform: translate(0,200%);
+}
+
+.c3.direction-column.position-right-top,
+.c3.direction-column.position-right-center,
+.c3.direction-column.position-right-bottom {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c3.direction-row.position-left-top,
+.c3.direction-row.position-center-top,
+.c3.direction-row.position-right-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c3.direction-row.position-left-center {
+  -webkit-transform: translate(-200%,0);
+  -ms-transform: translate(-200%,0);
+  transform: translate(-200%,0);
+}
+
+.c3.direction-row.position-right-center {
+  -webkit-transform: translate(200%,0);
+  -ms-transform: translate(200%,0);
+  transform: translate(200%,0);
+}
+
+.c3.direction-row.position-left-bottom,
+.c3.direction-row.position-center-bottom,
+.c3.direction-row.position-right-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c3.direction-column.position-left-top.opened,
+.c3.direction-row.position-left-top.opened,
+.c3.direction-column.position-center-top.opened,
+.c3.direction-row.position-center-top.opened,
+.c3.direction-column.position-right-top.opened,
+.c3.direction-row.position-right-top.opened,
+.c3.direction-column.position-right-center.opened,
+.c3.direction-row.position-right-center.opened,
+.c3.direction-column.position-right-bottom.opened,
+.c3.direction-row.position-right-bottom.opened,
+.c3.direction-column.position-center-bottom.opened,
+.c3.direction-row.position-center-bottom.opened,
+.c3.direction-column.position-left-bottom.opened,
+.c3.direction-row.position-left-bottom.opened,
+.c3.direction-column.position-left-center.opened,
+.c3.direction-row.position-left-center.opened {
+  -webkit-transform: translate(0,0);
+  -ms-transform: translate(0,0);
+  transform: translate(0,0);
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="position-left-top direction-column sc-eNQAEJ kJIalf"
+    className="position-left-top direction-column c1"
   >
     <button
-      className="md shape-round btn sc-kpOJdX deOJdy"
+      className="md shape-round btn c2"
       onClick={[Function]}
       size="md"
     >
@@ -79,7 +847,7 @@ exports[`When using snapshots Should render with the direction prop 1`] = `
       />
     </button>
     <div
-      className="position-left-top direction-column sc-hMqMXs frWmYS"
+      className="position-left-top direction-column c3"
       onClick={null}
     >
       <div
@@ -91,14 +859,270 @@ exports[`When using snapshots Should render with the direction prop 1`] = `
 `;
 
 exports[`When using snapshots Should render with the opened prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c2,
+.c2.btn {
+  position: relative;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  pointer-events: all;
+  color: #101113;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  background: #ffffff;
+  font-weight: 500;
+  padding: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c2.shape-square {
+  border-radius: 4px;
+}
+
+.c2.shape-round {
+  border-radius: 50%;
+}
+
+.c2.xs {
+  width: 2.4rem;
+  height: 2.4rem;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.c2.xs .fa {
+  font-size: 1.2rem;
+}
+
+.c2.sm {
+  width: 3rem;
+  height: 3rem;
+  line-height: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.c2.sm .fa {
+  font-size: 1.4rem;
+}
+
+.c2.md {
+  width: 4rem;
+  height: 4rem;
+  line-height: 1.6rem;
+  font-size: 1.4rem;
+}
+
+.c2.md .fa {
+  font-size: 1.6rem;
+}
+
+.c2.lg {
+  width: 5rem;
+  height: 5rem;
+  line-height: 1.7rem;
+  font-size: 1.8rem;
+}
+
+.c2.lg .fa {
+  font-size: 2rem;
+}
+
+.c2.in-group {
+  width: calc(4rem - (2px * 2));
+  height: calc(4rem - (2px * 2));
+  border-width: 0;
+  box-shadow: none;
+}
+
+.c2.btn:hover {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:hover.in-group {
+  border-color: #eceeef;
+}
+
+.c2.btn:focus {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:focus.in-group {
+  border-color: #eceeef;
+}
+
+.c2.btn:active,
+.c2.btn.active {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:active.in-group,
+.c2.btn.active.in-group {
+  border-color: #eceeef;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c3.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3.direction-column.position-left-center > *,
+.c3.direction-column.position-left-top > *,
+.c3.direction-column.position-center-top > *,
+.c3.direction-column.position-right-top > *,
+.c3.direction-column.position-right-center > * {
+  margin-top: .8rem;
+}
+
+.c3.direction-column.position-left-bottom > *,
+.c3.direction-column.position-center-bottom > *,
+.c3.direction-column.position-right-bottom > * {
+  margin-bottom: .8rem;
+}
+
+.c3.direction-row.position-center-top > *,
+.c3.direction-row.position-left-top > *,
+.c3.direction-row.position-left-center > *,
+.c3.direction-row.position-left-bottom > *,
+.c3.direction-row.position-center-bottom > * {
+  margin-left: .8rem;
+}
+
+.c3.direction-row.position-right-top > *,
+.c3.direction-row.position-right-center > *,
+.c3.direction-row.position-right-bottom > * {
+  margin-right: .8rem;
+}
+
+.c3.direction-column.position-left-top,
+.c3.direction-column.position-left-center,
+.c3.direction-column.position-left-bottom {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c3.direction-column.position-center-top {
+  -webkit-transform: translate(0,-200%);
+  -ms-transform: translate(0,-200%);
+  transform: translate(0,-200%);
+}
+
+.c3.direction-column.position-center-bottom {
+  -webkit-transform: translate(0,200%);
+  -ms-transform: translate(0,200%);
+  transform: translate(0,200%);
+}
+
+.c3.direction-column.position-right-top,
+.c3.direction-column.position-right-center,
+.c3.direction-column.position-right-bottom {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c3.direction-row.position-left-top,
+.c3.direction-row.position-center-top,
+.c3.direction-row.position-right-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c3.direction-row.position-left-center {
+  -webkit-transform: translate(-200%,0);
+  -ms-transform: translate(-200%,0);
+  transform: translate(-200%,0);
+}
+
+.c3.direction-row.position-right-center {
+  -webkit-transform: translate(200%,0);
+  -ms-transform: translate(200%,0);
+  transform: translate(200%,0);
+}
+
+.c3.direction-row.position-left-bottom,
+.c3.direction-row.position-center-bottom,
+.c3.direction-row.position-right-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c3.direction-column.position-left-top.opened,
+.c3.direction-row.position-left-top.opened,
+.c3.direction-column.position-center-top.opened,
+.c3.direction-row.position-center-top.opened,
+.c3.direction-column.position-right-top.opened,
+.c3.direction-row.position-right-top.opened,
+.c3.direction-column.position-right-center.opened,
+.c3.direction-row.position-right-center.opened,
+.c3.direction-column.position-right-bottom.opened,
+.c3.direction-row.position-right-bottom.opened,
+.c3.direction-column.position-center-bottom.opened,
+.c3.direction-row.position-center-bottom.opened,
+.c3.direction-column.position-left-bottom.opened,
+.c3.direction-row.position-left-bottom.opened,
+.c3.direction-column.position-left-center.opened,
+.c3.direction-row.position-left-center.opened {
+  -webkit-transform: translate(0,0);
+  -ms-transform: translate(0,0);
+  transform: translate(0,0);
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="position-left-top direction-column opened sc-eNQAEJ kJIalf"
+    className="position-left-top direction-column opened c1"
   >
     <button
-      className="md shape-round btn sc-kpOJdX deOJdy"
+      className="md shape-round btn c2"
       onClick={[Function]}
       size="md"
     >
@@ -109,7 +1133,7 @@ exports[`When using snapshots Should render with the opened prop 1`] = `
       />
     </button>
     <div
-      className="position-left-top direction-column opened sc-hMqMXs frWmYS"
+      className="position-left-top direction-column opened c3"
       onClick={null}
     >
       <div
@@ -121,14 +1145,270 @@ exports[`When using snapshots Should render with the opened prop 1`] = `
 `;
 
 exports[`When using snapshots Should render with the shape prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c2,
+.c2.btn {
+  position: relative;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  pointer-events: all;
+  color: #101113;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  background: #ffffff;
+  font-weight: 500;
+  padding: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c2.shape-square {
+  border-radius: 4px;
+}
+
+.c2.shape-round {
+  border-radius: 50%;
+}
+
+.c2.xs {
+  width: 2.4rem;
+  height: 2.4rem;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.c2.xs .fa {
+  font-size: 1.2rem;
+}
+
+.c2.sm {
+  width: 3rem;
+  height: 3rem;
+  line-height: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.c2.sm .fa {
+  font-size: 1.4rem;
+}
+
+.c2.md {
+  width: 4rem;
+  height: 4rem;
+  line-height: 1.6rem;
+  font-size: 1.4rem;
+}
+
+.c2.md .fa {
+  font-size: 1.6rem;
+}
+
+.c2.lg {
+  width: 5rem;
+  height: 5rem;
+  line-height: 1.7rem;
+  font-size: 1.8rem;
+}
+
+.c2.lg .fa {
+  font-size: 2rem;
+}
+
+.c2.in-group {
+  width: calc(4rem - (2px * 2));
+  height: calc(4rem - (2px * 2));
+  border-width: 0;
+  box-shadow: none;
+}
+
+.c2.btn:hover {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:hover.in-group {
+  border-color: #eceeef;
+}
+
+.c2.btn:focus {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:focus.in-group {
+  border-color: #eceeef;
+}
+
+.c2.btn:active,
+.c2.btn.active {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:active.in-group,
+.c2.btn.active.in-group {
+  border-color: #eceeef;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c3.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3.direction-column.position-left-center > *,
+.c3.direction-column.position-left-top > *,
+.c3.direction-column.position-center-top > *,
+.c3.direction-column.position-right-top > *,
+.c3.direction-column.position-right-center > * {
+  margin-top: .8rem;
+}
+
+.c3.direction-column.position-left-bottom > *,
+.c3.direction-column.position-center-bottom > *,
+.c3.direction-column.position-right-bottom > * {
+  margin-bottom: .8rem;
+}
+
+.c3.direction-row.position-center-top > *,
+.c3.direction-row.position-left-top > *,
+.c3.direction-row.position-left-center > *,
+.c3.direction-row.position-left-bottom > *,
+.c3.direction-row.position-center-bottom > * {
+  margin-left: .8rem;
+}
+
+.c3.direction-row.position-right-top > *,
+.c3.direction-row.position-right-center > *,
+.c3.direction-row.position-right-bottom > * {
+  margin-right: .8rem;
+}
+
+.c3.direction-column.position-left-top,
+.c3.direction-column.position-left-center,
+.c3.direction-column.position-left-bottom {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c3.direction-column.position-center-top {
+  -webkit-transform: translate(0,-200%);
+  -ms-transform: translate(0,-200%);
+  transform: translate(0,-200%);
+}
+
+.c3.direction-column.position-center-bottom {
+  -webkit-transform: translate(0,200%);
+  -ms-transform: translate(0,200%);
+  transform: translate(0,200%);
+}
+
+.c3.direction-column.position-right-top,
+.c3.direction-column.position-right-center,
+.c3.direction-column.position-right-bottom {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c3.direction-row.position-left-top,
+.c3.direction-row.position-center-top,
+.c3.direction-row.position-right-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c3.direction-row.position-left-center {
+  -webkit-transform: translate(-200%,0);
+  -ms-transform: translate(-200%,0);
+  transform: translate(-200%,0);
+}
+
+.c3.direction-row.position-right-center {
+  -webkit-transform: translate(200%,0);
+  -ms-transform: translate(200%,0);
+  transform: translate(200%,0);
+}
+
+.c3.direction-row.position-left-bottom,
+.c3.direction-row.position-center-bottom,
+.c3.direction-row.position-right-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c3.direction-column.position-left-top.opened,
+.c3.direction-row.position-left-top.opened,
+.c3.direction-column.position-center-top.opened,
+.c3.direction-row.position-center-top.opened,
+.c3.direction-column.position-right-top.opened,
+.c3.direction-row.position-right-top.opened,
+.c3.direction-column.position-right-center.opened,
+.c3.direction-row.position-right-center.opened,
+.c3.direction-column.position-right-bottom.opened,
+.c3.direction-row.position-right-bottom.opened,
+.c3.direction-column.position-center-bottom.opened,
+.c3.direction-row.position-center-bottom.opened,
+.c3.direction-column.position-left-bottom.opened,
+.c3.direction-row.position-left-bottom.opened,
+.c3.direction-column.position-left-center.opened,
+.c3.direction-row.position-left-center.opened {
+  -webkit-transform: translate(0,0);
+  -ms-transform: translate(0,0);
+  transform: translate(0,0);
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="position-left-top direction-column sc-eNQAEJ kJIalf"
+    className="position-left-top direction-column c1"
   >
     <button
-      className="md shape-round btn sc-kpOJdX deOJdy"
+      className="md shape-round btn c2"
       onClick={[Function]}
       size="md"
     >
@@ -139,7 +1419,7 @@ exports[`When using snapshots Should render with the shape prop 1`] = `
       />
     </button>
     <div
-      className="position-left-top direction-column sc-hMqMXs frWmYS"
+      className="position-left-top direction-column c3"
       onClick={null}
     >
       <div
@@ -152,14 +1432,270 @@ exports[`When using snapshots Should render with the shape prop 1`] = `
 `;
 
 exports[`When using snapshots Should render with the size prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c2,
+.c2.btn {
+  position: relative;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  pointer-events: all;
+  color: #101113;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  background: #ffffff;
+  font-weight: 500;
+  padding: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c2.shape-square {
+  border-radius: 4px;
+}
+
+.c2.shape-round {
+  border-radius: 50%;
+}
+
+.c2.xs {
+  width: 2.4rem;
+  height: 2.4rem;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.c2.xs .fa {
+  font-size: 1.2rem;
+}
+
+.c2.sm {
+  width: 3rem;
+  height: 3rem;
+  line-height: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.c2.sm .fa {
+  font-size: 1.4rem;
+}
+
+.c2.md {
+  width: 4rem;
+  height: 4rem;
+  line-height: 1.6rem;
+  font-size: 1.4rem;
+}
+
+.c2.md .fa {
+  font-size: 1.6rem;
+}
+
+.c2.lg {
+  width: 5rem;
+  height: 5rem;
+  line-height: 1.7rem;
+  font-size: 1.8rem;
+}
+
+.c2.lg .fa {
+  font-size: 2rem;
+}
+
+.c2.in-group {
+  width: calc(4rem - (2px * 2));
+  height: calc(4rem - (2px * 2));
+  border-width: 0;
+  box-shadow: none;
+}
+
+.c2.btn:hover {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:hover.in-group {
+  border-color: #eceeef;
+}
+
+.c2.btn:focus {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:focus.in-group {
+  border-color: #eceeef;
+}
+
+.c2.btn:active,
+.c2.btn.active {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c2.btn:active.in-group,
+.c2.btn.active.in-group {
+  border-color: #eceeef;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3 {
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+}
+
+.c3.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c3.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c3.direction-column.position-left-center > *,
+.c3.direction-column.position-left-top > *,
+.c3.direction-column.position-center-top > *,
+.c3.direction-column.position-right-top > *,
+.c3.direction-column.position-right-center > * {
+  margin-top: .8rem;
+}
+
+.c3.direction-column.position-left-bottom > *,
+.c3.direction-column.position-center-bottom > *,
+.c3.direction-column.position-right-bottom > * {
+  margin-bottom: .8rem;
+}
+
+.c3.direction-row.position-center-top > *,
+.c3.direction-row.position-left-top > *,
+.c3.direction-row.position-left-center > *,
+.c3.direction-row.position-left-bottom > *,
+.c3.direction-row.position-center-bottom > * {
+  margin-left: .8rem;
+}
+
+.c3.direction-row.position-right-top > *,
+.c3.direction-row.position-right-center > *,
+.c3.direction-row.position-right-bottom > * {
+  margin-right: .8rem;
+}
+
+.c3.direction-column.position-left-top,
+.c3.direction-column.position-left-center,
+.c3.direction-column.position-left-bottom {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c3.direction-column.position-center-top {
+  -webkit-transform: translate(0,-200%);
+  -ms-transform: translate(0,-200%);
+  transform: translate(0,-200%);
+}
+
+.c3.direction-column.position-center-bottom {
+  -webkit-transform: translate(0,200%);
+  -ms-transform: translate(0,200%);
+  transform: translate(0,200%);
+}
+
+.c3.direction-column.position-right-top,
+.c3.direction-column.position-right-center,
+.c3.direction-column.position-right-bottom {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c3.direction-row.position-left-top,
+.c3.direction-row.position-center-top,
+.c3.direction-row.position-right-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c3.direction-row.position-left-center {
+  -webkit-transform: translate(-200%,0);
+  -ms-transform: translate(-200%,0);
+  transform: translate(-200%,0);
+}
+
+.c3.direction-row.position-right-center {
+  -webkit-transform: translate(200%,0);
+  -ms-transform: translate(200%,0);
+  transform: translate(200%,0);
+}
+
+.c3.direction-row.position-left-bottom,
+.c3.direction-row.position-center-bottom,
+.c3.direction-row.position-right-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c3.direction-column.position-left-top.opened,
+.c3.direction-row.position-left-top.opened,
+.c3.direction-column.position-center-top.opened,
+.c3.direction-row.position-center-top.opened,
+.c3.direction-column.position-right-top.opened,
+.c3.direction-row.position-right-top.opened,
+.c3.direction-column.position-right-center.opened,
+.c3.direction-row.position-right-center.opened,
+.c3.direction-column.position-right-bottom.opened,
+.c3.direction-row.position-right-bottom.opened,
+.c3.direction-column.position-center-bottom.opened,
+.c3.direction-row.position-center-bottom.opened,
+.c3.direction-column.position-left-bottom.opened,
+.c3.direction-row.position-left-bottom.opened,
+.c3.direction-column.position-left-center.opened,
+.c3.direction-row.position-left-center.opened {
+  -webkit-transform: translate(0,0);
+  -ms-transform: translate(0,0);
+  transform: translate(0,0);
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="position-left-top direction-column sc-eNQAEJ kJIalf"
+    className="position-left-top direction-column c1"
   >
     <button
-      className="md shape-round btn sc-kpOJdX deOJdy"
+      className="md shape-round btn c2"
       onClick={[Function]}
       size="md"
     >
@@ -170,7 +1706,7 @@ exports[`When using snapshots Should render with the size prop 1`] = `
       />
     </button>
     <div
-      className="position-left-top direction-column sc-hMqMXs frWmYS"
+      className="position-left-top direction-column c3"
       onClick={null}
     >
       <div

--- a/src/components/Toolbar/__tests__/__snapshots__/Group.test.jsx.snap
+++ b/src/components/Toolbar/__tests__/__snapshots__/Group.test.jsx.snap
@@ -1,11 +1,72 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #ffffff;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1.direction-column > * {
+  margin-bottom: .8rem;
+}
+
+.c1.direction-row > * {
+  margin-right: .8rem;
+}
+
+.c1.direction-column :last-child,
+.c1.direction-row :last-child {
+  margin: 0;
+}
+
+.c1.direction-column.first-shape-square {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.c1.direction-column.last-shape-square {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c1.direction-row.first-shape-square {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+.c1.direction-row.last-shape-square {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="direction-column first-shape- last-shape- first-size- last-size- sc-jKJlTe glzJbk"
+    className="direction-column first-shape- last-shape- first-size- last-size- c1"
   >
     <div
       inGroup={true}
@@ -15,11 +76,72 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots Should render with the direction prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #ffffff;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1.direction-column > * {
+  margin-bottom: .8rem;
+}
+
+.c1.direction-row > * {
+  margin-right: .8rem;
+}
+
+.c1.direction-column :last-child,
+.c1.direction-row :last-child {
+  margin: 0;
+}
+
+.c1.direction-column.first-shape-square {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.c1.direction-column.last-shape-square {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c1.direction-row.first-shape-square {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+.c1.direction-row.last-shape-square {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="direction-column first-shape- last-shape- first-size- last-size- sc-jKJlTe glzJbk"
+    className="direction-column first-shape- last-shape- first-size- last-size- c1"
   >
     <div
       inGroup={true}
@@ -29,11 +151,72 @@ exports[`When using snapshots Should render with the direction prop 1`] = `
 `;
 
 exports[`When using snapshots Should render with the shape prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #ffffff;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1.direction-column > * {
+  margin-bottom: .8rem;
+}
+
+.c1.direction-row > * {
+  margin-right: .8rem;
+}
+
+.c1.direction-column :last-child,
+.c1.direction-row :last-child {
+  margin: 0;
+}
+
+.c1.direction-column.first-shape-square {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.c1.direction-column.last-shape-square {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c1.direction-row.first-shape-square {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+.c1.direction-row.last-shape-square {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="direction-column first-shape-square last-shape-square first-size- last-size- sc-jKJlTe glzJbk"
+    className="direction-column first-shape-square last-shape-square first-size- last-size- c1"
   >
     <div
       inGroup={true}
@@ -44,11 +227,92 @@ exports[`When using snapshots Should render with the shape prop 1`] = `
 `;
 
 exports[`When using snapshots Should render with the size prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  background: #ffffff;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1.direction-column > * {
+  margin-bottom: .8rem;
+}
+
+.c1.direction-row > * {
+  margin-right: .8rem;
+}
+
+.c1.direction-column :last-child,
+.c1.direction-row :last-child {
+  margin: 0;
+}
+
+.c1.direction-column.first-shape-square {
+  border-top-left-radius: 4px;
+  border-top-right-radius: 4px;
+}
+
+.c1.direction-column.last-shape-square {
+  border-bottom-left-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c1.direction-column.first-shape-round {
+  border-top-left-radius: 2.4rem;
+  border-top-right-radius: 2.4rem;
+}
+
+.c1.direction-column.last-shape-round {
+  border-bottom-left-radius: 2.4rem;
+  border-bottom-right-radius: 2.4rem;
+}
+
+.c1.direction-row.first-shape-square {
+  border-top-left-radius: 4px;
+  border-bottom-left-radius: 4px;
+}
+
+.c1.direction-row.last-shape-square {
+  border-top-right-radius: 4px;
+  border-bottom-right-radius: 4px;
+}
+
+.c1.direction-row.first-shape-round {
+  border-top-left-radius: 2.4rem;
+  border-bottom-left-radius: 2.4rem;
+}
+
+.c1.direction-row.last-shape-round {
+  border-top-right-radius: 2.4rem;
+  border-bottom-right-radius: 2.4rem;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <div
-    className="direction-column first-shape- last-shape- first-size-xs last-size-xs sc-jKJlTe dRnmix"
+    className="direction-column first-shape- last-shape- first-size-xs last-size-xs c1"
   >
     <div
       inGroup={true}

--- a/src/components/Toolbar/__tests__/__snapshots__/Item.test.jsx.snap
+++ b/src/components/Toolbar/__tests__/__snapshots__/Item.test.jsx.snap
@@ -1,11 +1,122 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1,
+.c1.btn {
+  position: relative;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  pointer-events: all;
+  color: #101113;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  background: #ffffff;
+  font-weight: 500;
+  padding: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.shape-square {
+  border-radius: 4px;
+}
+
+.c1.shape-round {
+  border-radius: 50%;
+}
+
+.c1.xs {
+  width: 2.4rem;
+  height: 2.4rem;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.c1.xs .fa {
+  font-size: 1.2rem;
+}
+
+.c1.sm {
+  width: 3rem;
+  height: 3rem;
+  line-height: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.c1.sm .fa {
+  font-size: 1.4rem;
+}
+
+.c1.md {
+  width: 4rem;
+  height: 4rem;
+  line-height: 1.6rem;
+  font-size: 1.4rem;
+}
+
+.c1.md .fa {
+  font-size: 1.6rem;
+}
+
+.c1.lg {
+  width: 5rem;
+  height: 5rem;
+  line-height: 1.7rem;
+  font-size: 1.8rem;
+}
+
+.c1.lg .fa {
+  font-size: 2rem;
+}
+
+.c1.in-group {
+  width: calc(4rem - (2px * 2));
+  height: calc(4rem - (2px * 2));
+  border-width: 0;
+  box-shadow: none;
+}
+
+.c1.btn:hover {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:hover.in-group {
+  border-color: #eceeef;
+}
+
+.c1.btn:focus {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:focus.in-group {
+  border-color: #eceeef;
+}
+
+.c1.btn:active,
+.c1.btn.active {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:active.in-group,
+.c1.btn.active.in-group {
+  border-color: #eceeef;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <button
-    className="md shape-round btn sc-kpOJdX deOJdy"
+    className="md shape-round btn c1"
     size="md"
   >
     <div />
@@ -14,11 +125,126 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots Should render with the inactive prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  pointer-events: none;
+}
+
+.c1,
+.c1.btn {
+  position: relative;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  pointer-events: all;
+  color: #101113;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  background: #ffffff;
+  font-weight: 500;
+  padding: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.shape-square {
+  border-radius: 4px;
+}
+
+.c1.shape-round {
+  border-radius: 50%;
+}
+
+.c1.xs {
+  width: 2.4rem;
+  height: 2.4rem;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.c1.xs .fa {
+  font-size: 1.2rem;
+}
+
+.c1.sm {
+  width: 3rem;
+  height: 3rem;
+  line-height: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.c1.sm .fa {
+  font-size: 1.4rem;
+}
+
+.c1.md {
+  width: 4rem;
+  height: 4rem;
+  line-height: 1.6rem;
+  font-size: 1.4rem;
+}
+
+.c1.md .fa {
+  font-size: 1.6rem;
+}
+
+.c1.lg {
+  width: 5rem;
+  height: 5rem;
+  line-height: 1.7rem;
+  font-size: 1.8rem;
+}
+
+.c1.lg .fa {
+  font-size: 2rem;
+}
+
+.c1.in-group {
+  width: calc(4rem - (2px * 2));
+  height: calc(4rem - (2px * 2));
+  border-width: 0;
+  box-shadow: none;
+}
+
+.c1.btn:hover {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:hover.in-group {
+  border-color: #eceeef;
+}
+
+.c1.btn:focus {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:focus.in-group {
+  border-color: #eceeef;
+}
+
+.c1.btn:active,
+.c1.btn.active {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:active.in-group,
+.c1.btn.active.in-group {
+  border-color: #eceeef;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <button
-    className="md shape-round sc-dxgOiQ GhCit"
+    className="md shape-round c1"
     size="md"
   >
     <div />
@@ -27,19 +253,169 @@ exports[`When using snapshots Should render with the inactive prop 1`] = `
 `;
 
 exports[`When using snapshots Should render with the loading prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c3 {
+  width: 2.4rem;
+  height: 2.4rem;
+  margin: 0 auto;
+  border-width: 3px;
+  border-style: solid;
+  border-color: #707377;
+  border-radius: 50%;
+  border-left-color: transparent;
+  border-bottom-color: transparent;
+  border-right-color: transparent;
+  -webkit-animation: iVXCSc 650ms infinite linear;
+  animation: iVXCSc 650ms infinite linear;
+}
+
+.c2 {
+  text-align: center;
+}
+
+.c2.centered {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1,
+.c1.btn {
+  position: relative;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  pointer-events: all;
+  color: #101113;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  background: #ffffff;
+  font-weight: 500;
+  padding: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.shape-square {
+  border-radius: 4px;
+}
+
+.c1.shape-round {
+  border-radius: 50%;
+}
+
+.c1.xs {
+  width: 2.4rem;
+  height: 2.4rem;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.c1.xs .fa {
+  font-size: 1.2rem;
+}
+
+.c1.sm {
+  width: 3rem;
+  height: 3rem;
+  line-height: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.c1.sm .fa {
+  font-size: 1.4rem;
+}
+
+.c1.md {
+  width: 4rem;
+  height: 4rem;
+  line-height: 1.6rem;
+  font-size: 1.4rem;
+}
+
+.c1.md .fa {
+  font-size: 1.6rem;
+}
+
+.c1.lg {
+  width: 5rem;
+  height: 5rem;
+  line-height: 1.7rem;
+  font-size: 1.8rem;
+}
+
+.c1.lg .fa {
+  font-size: 2rem;
+}
+
+.c1.in-group {
+  width: calc(4rem - (2px * 2));
+  height: calc(4rem - (2px * 2));
+  border-width: 0;
+  box-shadow: none;
+}
+
+.c1.btn:hover {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:hover.in-group {
+  border-color: #eceeef;
+}
+
+.c1.btn:focus {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:focus.in-group {
+  border-color: #eceeef;
+}
+
+.c1.btn:active,
+.c1.btn.active {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:active.in-group,
+.c1.btn.active.in-group {
+  border-color: #eceeef;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <button
-    className="loading md shape-round btn sc-kpOJdX deOJdy"
+    className="loading md shape-round btn c1"
     size="md"
   >
     <div
-      className="centered sc-bxivhb gIwMIC"
+      className="centered c2"
     >
       <div>
         <div
-          className="sc-htpNat eBWglT"
+          className="c3"
         />
         
       </div>
@@ -49,11 +425,122 @@ exports[`When using snapshots Should render with the loading prop 1`] = `
 `;
 
 exports[`When using snapshots Should render with the shape prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1,
+.c1.btn {
+  position: relative;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  pointer-events: all;
+  color: #101113;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  background: #ffffff;
+  font-weight: 500;
+  padding: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.shape-square {
+  border-radius: 4px;
+}
+
+.c1.shape-round {
+  border-radius: 50%;
+}
+
+.c1.xs {
+  width: 2.4rem;
+  height: 2.4rem;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.c1.xs .fa {
+  font-size: 1.2rem;
+}
+
+.c1.sm {
+  width: 3rem;
+  height: 3rem;
+  line-height: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.c1.sm .fa {
+  font-size: 1.4rem;
+}
+
+.c1.md {
+  width: 4rem;
+  height: 4rem;
+  line-height: 1.6rem;
+  font-size: 1.4rem;
+}
+
+.c1.md .fa {
+  font-size: 1.6rem;
+}
+
+.c1.lg {
+  width: 5rem;
+  height: 5rem;
+  line-height: 1.7rem;
+  font-size: 1.8rem;
+}
+
+.c1.lg .fa {
+  font-size: 2rem;
+}
+
+.c1.in-group {
+  width: calc(4rem - (2px * 2));
+  height: calc(4rem - (2px * 2));
+  border-width: 0;
+  box-shadow: none;
+}
+
+.c1.btn:hover {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:hover.in-group {
+  border-color: #eceeef;
+}
+
+.c1.btn:focus {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:focus.in-group {
+  border-color: #eceeef;
+}
+
+.c1.btn:active,
+.c1.btn.active {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:active.in-group,
+.c1.btn.active.in-group {
+  border-color: #eceeef;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <button
-    className="md shape-square btn sc-kpOJdX deOJdy"
+    className="md shape-square btn c1"
     size="md"
   >
     <div />
@@ -62,11 +549,122 @@ exports[`When using snapshots Should render with the shape prop 1`] = `
 `;
 
 exports[`When using snapshots Should render with the size prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1,
+.c1.btn {
+  position: relative;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  pointer-events: all;
+  color: #101113;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  background: #ffffff;
+  font-weight: 500;
+  padding: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.shape-square {
+  border-radius: 4px;
+}
+
+.c1.shape-round {
+  border-radius: 50%;
+}
+
+.c1.xs {
+  width: 2.4rem;
+  height: 2.4rem;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.c1.xs .fa {
+  font-size: 1.2rem;
+}
+
+.c1.sm {
+  width: 3rem;
+  height: 3rem;
+  line-height: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.c1.sm .fa {
+  font-size: 1.4rem;
+}
+
+.c1.md {
+  width: 4rem;
+  height: 4rem;
+  line-height: 1.6rem;
+  font-size: 1.4rem;
+}
+
+.c1.md .fa {
+  font-size: 1.6rem;
+}
+
+.c1.lg {
+  width: 5rem;
+  height: 5rem;
+  line-height: 1.7rem;
+  font-size: 1.8rem;
+}
+
+.c1.lg .fa {
+  font-size: 2rem;
+}
+
+.c1.in-group {
+  width: calc(2.4rem - (2px * 2));
+  height: calc(2.4rem - (2px * 2));
+  border-width: 0;
+  box-shadow: none;
+}
+
+.c1.btn:hover {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:hover.in-group {
+  border-color: #eceeef;
+}
+
+.c1.btn:focus {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:focus.in-group {
+  border-color: #eceeef;
+}
+
+.c1.btn:active,
+.c1.btn.active {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:active.in-group,
+.c1.btn.active.in-group {
+  border-color: #eceeef;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <button
-    className="xs shape-round btn sc-kpOJdX jYFmnc"
+    className="xs shape-round btn c1"
     size="xs"
   >
     <div />
@@ -75,11 +673,138 @@ exports[`When using snapshots Should render with the size prop 1`] = `
 `;
 
 exports[`When using snapshots Should render with the type prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+  font-weight: 500;
+}
+
+.c1,
+.c1.btn {
+  position: relative;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  pointer-events: all;
+  color: #101113;
+  border-color: #c9cacc;
+  border-style: solid;
+  border-width: 2px;
+  background: #ffffff;
+  font-weight: 500;
+  padding: 0;
+  box-shadow: 0 3px 4px -3px rgba(0,0,0,0.5),0 0 2px -1px rgba(0,0,0,0.4);
+}
+
+.c1.shape-square {
+  border-radius: 4px;
+}
+
+.c1.shape-round {
+  border-radius: 50%;
+}
+
+.c1.xs {
+  width: 2.4rem;
+  height: 2.4rem;
+  line-height: 1rem;
+  font-size: 1rem;
+}
+
+.c1.xs .fa {
+  font-size: 1.2rem;
+}
+
+.c1.sm {
+  width: 3rem;
+  height: 3rem;
+  line-height: 1.2rem;
+  font-size: 1.2rem;
+}
+
+.c1.sm .fa {
+  font-size: 1.4rem;
+}
+
+.c1.md {
+  width: 4rem;
+  height: 4rem;
+  line-height: 1.6rem;
+  font-size: 1.4rem;
+}
+
+.c1.md .fa {
+  font-size: 1.6rem;
+}
+
+.c1.lg {
+  width: 5rem;
+  height: 5rem;
+  line-height: 1.7rem;
+  font-size: 1.8rem;
+}
+
+.c1.lg .fa {
+  font-size: 2rem;
+}
+
+.c1.in-group {
+  width: calc(4rem - (2px * 2));
+  height: calc(4rem - (2px * 2));
+  border-width: 0;
+  box-shadow: none;
+}
+
+.c1.btn:hover {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:hover.in-group {
+  border-color: #eceeef;
+}
+
+.c1.btn:focus {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:focus.in-group {
+  border-color: #eceeef;
+}
+
+.c1.btn:active,
+.c1.btn.active {
+  color: #101113;
+  background-color: #eceeef;
+  border-color: #c9cacc;
+}
+
+.c1.btn:active.in-group,
+.c1.btn.active.in-group {
+  border-color: #eceeef;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <button
-    className="md shape-round btn sc-ckVGcZ fiLVzO"
+    className="md shape-round btn c1"
     size="md"
   >
     <div />

--- a/src/components/Toolbar/__tests__/__snapshots__/Toolbar.test.jsx.snap
+++ b/src/components/Toolbar/__tests__/__snapshots__/Toolbar.test.jsx.snap
@@ -1,11 +1,233 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`When using snapshots Should render with an element children 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  z-index: 1000;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 1rem;
+  pointer-events: none;
+}
+
+.c1.container-parent {
+  position: absolute;
+}
+
+.c1.container-root {
+  position: fixed;
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-left-center,
+.c1.direction-row.position-left-bottom {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-center-center,
+.c1.direction-row.position-center-bottom {
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.direction-row.position-right-top,
+.c1.direction-row.position-right-center,
+.c1.direction-row.position-right-bottom {
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-right-top {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c1.direction-row.position-left-center,
+.c1.direction-row.position-center-center,
+.c1.direction-row.position-right-center {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.direction-row.position-left-bottom,
+.c1.direction-row.position-center-bottom,
+.c1.direction-row.position-right-bottom {
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-center-top,
+.c1.direction-column.position-right-top {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-center-center,
+.c1.direction-column.position-right-center {
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.direction-column.position-left-bottom,
+.c1.direction-column.position-center-bottom,
+.c1.direction-column.position-right-bottom {
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-left-bottom {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c1.direction-column.position-center-top,
+.c1.direction-column.position-center-center,
+.c1.direction-column.position-center-bottom {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.direction-column.position-right-top,
+.c1.direction-column.position-right-center,
+.c1.direction-column.position-right-bottom {
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-left-bottom {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c1.direction-column.position-center-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c1.direction-column.position-center-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c1.direction-column.position-right-top,
+.c1.direction-column.position-right-center,
+.c1.direction-column.position-right-bottom {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-right-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c1.direction-row.position-left-center {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c1.direction-row.position-right-center {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c1.direction-row.position-left-bottom,
+.c1.direction-row.position-center-bottom,
+.c1.direction-row.position-right-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c1.direction-column.position-center-center,
+.c1.direction-row.position-center-center {
+  opacity: 0;
+}
+
+.c1.direction-column > * {
+  margin-bottom: .8rem;
+}
+
+.c1.direction-row > * {
+  margin-right: .8rem;
+}
+
+.c1.direction-column :last-child,
+.c1.direction-row :last-child {
+  margin: 0;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <aside
-    className="position-left-top direction-column container-parent sc-kGXeez SzHZb"
+    className="position-left-top direction-column container-parent c1"
     style={undefined}
   >
     <div
@@ -17,11 +239,233 @@ exports[`When using snapshots Should render with an element children 1`] = `
 `;
 
 exports[`When using snapshots Should render with the direction prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  z-index: 1000;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 1rem;
+  pointer-events: none;
+}
+
+.c1.container-parent {
+  position: absolute;
+}
+
+.c1.container-root {
+  position: fixed;
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-left-center,
+.c1.direction-row.position-left-bottom {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-center-center,
+.c1.direction-row.position-center-bottom {
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.direction-row.position-right-top,
+.c1.direction-row.position-right-center,
+.c1.direction-row.position-right-bottom {
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-right-top {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c1.direction-row.position-left-center,
+.c1.direction-row.position-center-center,
+.c1.direction-row.position-right-center {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.direction-row.position-left-bottom,
+.c1.direction-row.position-center-bottom,
+.c1.direction-row.position-right-bottom {
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-center-top,
+.c1.direction-column.position-right-top {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-center-center,
+.c1.direction-column.position-right-center {
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.direction-column.position-left-bottom,
+.c1.direction-column.position-center-bottom,
+.c1.direction-column.position-right-bottom {
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-left-bottom {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c1.direction-column.position-center-top,
+.c1.direction-column.position-center-center,
+.c1.direction-column.position-center-bottom {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.direction-column.position-right-top,
+.c1.direction-column.position-right-center,
+.c1.direction-column.position-right-bottom {
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-left-bottom {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c1.direction-column.position-center-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c1.direction-column.position-center-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c1.direction-column.position-right-top,
+.c1.direction-column.position-right-center,
+.c1.direction-column.position-right-bottom {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-right-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c1.direction-row.position-left-center {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c1.direction-row.position-right-center {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c1.direction-row.position-left-bottom,
+.c1.direction-row.position-center-bottom,
+.c1.direction-row.position-right-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c1.direction-column.position-center-center,
+.c1.direction-row.position-center-center {
+  opacity: 0;
+}
+
+.c1.direction-column > * {
+  margin-bottom: .8rem;
+}
+
+.c1.direction-row > * {
+  margin-right: .8rem;
+}
+
+.c1.direction-column :last-child,
+.c1.direction-row :last-child {
+  margin: 0;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <aside
-    className="position-left-top direction-column container-parent sc-kGXeez SzHZb"
+    className="position-left-top direction-column container-parent c1"
     style={undefined}
   >
     <div
@@ -33,11 +477,233 @@ exports[`When using snapshots Should render with the direction prop 1`] = `
 `;
 
 exports[`When using snapshots Should render with the opened prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  z-index: 1000;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 1rem;
+  pointer-events: none;
+}
+
+.c1.container-parent {
+  position: absolute;
+}
+
+.c1.container-root {
+  position: fixed;
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-left-center,
+.c1.direction-row.position-left-bottom {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-center-center,
+.c1.direction-row.position-center-bottom {
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.direction-row.position-right-top,
+.c1.direction-row.position-right-center,
+.c1.direction-row.position-right-bottom {
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-right-top {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c1.direction-row.position-left-center,
+.c1.direction-row.position-center-center,
+.c1.direction-row.position-right-center {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.direction-row.position-left-bottom,
+.c1.direction-row.position-center-bottom,
+.c1.direction-row.position-right-bottom {
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-center-top,
+.c1.direction-column.position-right-top {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-center-center,
+.c1.direction-column.position-right-center {
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.direction-column.position-left-bottom,
+.c1.direction-column.position-center-bottom,
+.c1.direction-column.position-right-bottom {
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-left-bottom {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c1.direction-column.position-center-top,
+.c1.direction-column.position-center-center,
+.c1.direction-column.position-center-bottom {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.direction-column.position-right-top,
+.c1.direction-column.position-right-center,
+.c1.direction-column.position-right-bottom {
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-left-bottom {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c1.direction-column.position-center-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c1.direction-column.position-center-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c1.direction-column.position-right-top,
+.c1.direction-column.position-right-center,
+.c1.direction-column.position-right-bottom {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-right-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c1.direction-row.position-left-center {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c1.direction-row.position-right-center {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c1.direction-row.position-left-bottom,
+.c1.direction-row.position-center-bottom,
+.c1.direction-row.position-right-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c1.direction-column.position-center-center,
+.c1.direction-row.position-center-center {
+  opacity: 0;
+}
+
+.c1.direction-column > * {
+  margin-bottom: .8rem;
+}
+
+.c1.direction-row > * {
+  margin-right: .8rem;
+}
+
+.c1.direction-column :last-child,
+.c1.direction-row :last-child {
+  margin: 0;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <aside
-    className="position-left-top direction-column container-parent opened sc-kGXeez SzHZb"
+    className="position-left-top direction-column container-parent opened c1"
     style={
       Object {
         "opacity": 1,
@@ -54,11 +720,233 @@ exports[`When using snapshots Should render with the opened prop 1`] = `
 `;
 
 exports[`When using snapshots Should render with the shape prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  z-index: 1000;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 1rem;
+  pointer-events: none;
+}
+
+.c1.container-parent {
+  position: absolute;
+}
+
+.c1.container-root {
+  position: fixed;
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-left-center,
+.c1.direction-row.position-left-bottom {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-center-center,
+.c1.direction-row.position-center-bottom {
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.direction-row.position-right-top,
+.c1.direction-row.position-right-center,
+.c1.direction-row.position-right-bottom {
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-right-top {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c1.direction-row.position-left-center,
+.c1.direction-row.position-center-center,
+.c1.direction-row.position-right-center {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.direction-row.position-left-bottom,
+.c1.direction-row.position-center-bottom,
+.c1.direction-row.position-right-bottom {
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-center-top,
+.c1.direction-column.position-right-top {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-center-center,
+.c1.direction-column.position-right-center {
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.direction-column.position-left-bottom,
+.c1.direction-column.position-center-bottom,
+.c1.direction-column.position-right-bottom {
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-left-bottom {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c1.direction-column.position-center-top,
+.c1.direction-column.position-center-center,
+.c1.direction-column.position-center-bottom {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.direction-column.position-right-top,
+.c1.direction-column.position-right-center,
+.c1.direction-column.position-right-bottom {
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-left-bottom {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c1.direction-column.position-center-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c1.direction-column.position-center-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c1.direction-column.position-right-top,
+.c1.direction-column.position-right-center,
+.c1.direction-column.position-right-bottom {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-right-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c1.direction-row.position-left-center {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c1.direction-row.position-right-center {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c1.direction-row.position-left-bottom,
+.c1.direction-row.position-center-bottom,
+.c1.direction-row.position-right-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c1.direction-column.position-center-center,
+.c1.direction-row.position-center-center {
+  opacity: 0;
+}
+
+.c1.direction-column > * {
+  margin-bottom: .8rem;
+}
+
+.c1.direction-row > * {
+  margin-right: .8rem;
+}
+
+.c1.direction-column :last-child,
+.c1.direction-row :last-child {
+  margin: 0;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <aside
-    className="position-left-top direction-column container-parent sc-kGXeez SzHZb"
+    className="position-left-top direction-column container-parent c1"
     style={undefined}
   >
     <div
@@ -71,11 +959,233 @@ exports[`When using snapshots Should render with the shape prop 1`] = `
 `;
 
 exports[`When using snapshots Should render with the size prop 1`] = `
+.c0 {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}
+
+.c1 {
+  z-index: 1000;
+  -webkit-transition: all 0.1s ease-out;
+  transition: all 0.1s ease-out;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  margin: 1rem;
+  pointer-events: none;
+}
+
+.c1.container-parent {
+  position: absolute;
+}
+
+.c1.container-root {
+  position: fixed;
+}
+
+.c1.direction-row {
+  -webkit-flex-direction: row;
+  -ms-flex-direction: row;
+  flex-direction: row;
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-left-center,
+.c1.direction-row.position-left-bottom {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-center-center,
+.c1.direction-row.position-center-bottom {
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.direction-row.position-right-top,
+.c1.direction-row.position-right-center,
+.c1.direction-row.position-right-bottom {
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-right-top {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c1.direction-row.position-left-center,
+.c1.direction-row.position-center-center,
+.c1.direction-row.position-right-center {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.direction-row.position-left-bottom,
+.c1.direction-row.position-center-bottom,
+.c1.direction-row.position-right-bottom {
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c1.direction-column {
+  -webkit-flex-direction: column;
+  -ms-flex-direction: column;
+  flex-direction: column;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-center-top,
+.c1.direction-column.position-right-top {
+  -webkit-box-pack: start;
+  -webkit-justify-content: flex-start;
+  -ms-flex-pack: start;
+  justify-content: flex-start;
+}
+
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-center-center,
+.c1.direction-column.position-right-center {
+  -webkit-box-pack: center;
+  -webkit-justify-content: center;
+  -ms-flex-pack: center;
+  justify-content: center;
+}
+
+.c1.direction-column.position-left-bottom,
+.c1.direction-column.position-center-bottom,
+.c1.direction-column.position-right-bottom {
+  -webkit-box-pack: end;
+  -webkit-justify-content: flex-end;
+  -ms-flex-pack: end;
+  justify-content: flex-end;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-left-bottom {
+  -webkit-align-items: flex-start;
+  -webkit-box-align: flex-start;
+  -ms-flex-align: flex-start;
+  align-items: flex-start;
+}
+
+.c1.direction-column.position-center-top,
+.c1.direction-column.position-center-center,
+.c1.direction-column.position-center-bottom {
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.c1.direction-column.position-right-top,
+.c1.direction-column.position-right-center,
+.c1.direction-column.position-right-bottom {
+  -webkit-align-items: flex-end;
+  -webkit-box-align: flex-end;
+  -ms-flex-align: flex-end;
+  align-items: flex-end;
+}
+
+.c1.direction-column.position-left-top,
+.c1.direction-column.position-left-center,
+.c1.direction-column.position-left-bottom {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c1.direction-column.position-center-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c1.direction-column.position-center-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c1.direction-column.position-right-top,
+.c1.direction-column.position-right-center,
+.c1.direction-column.position-right-bottom {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c1.direction-row.position-left-top,
+.c1.direction-row.position-center-top,
+.c1.direction-row.position-right-top {
+  -webkit-transform: translate(0,-150%);
+  -ms-transform: translate(0,-150%);
+  transform: translate(0,-150%);
+}
+
+.c1.direction-row.position-left-center {
+  -webkit-transform: translate(-150%,0);
+  -ms-transform: translate(-150%,0);
+  transform: translate(-150%,0);
+}
+
+.c1.direction-row.position-right-center {
+  -webkit-transform: translate(150%,0);
+  -ms-transform: translate(150%,0);
+  transform: translate(150%,0);
+}
+
+.c1.direction-row.position-left-bottom,
+.c1.direction-row.position-center-bottom,
+.c1.direction-row.position-right-bottom {
+  -webkit-transform: translate(0,150%);
+  -ms-transform: translate(0,150%);
+  transform: translate(0,150%);
+}
+
+.c1.direction-column.position-center-center,
+.c1.direction-row.position-center-center {
+  opacity: 0;
+}
+
+.c1.direction-column > * {
+  margin-bottom: .8rem;
+}
+
+.c1.direction-row > * {
+  margin-right: .8rem;
+}
+
+.c1.direction-column :last-child,
+.c1.direction-row :last-child {
+  margin: 0;
+}
+
 <span
-  className="sc-bdVaJa lbJuWU"
+  className="c0"
 >
   <aside
-    className="position-left-top direction-column container-parent sc-kGXeez SzHZb"
+    className="position-left-top direction-column container-parent c1"
     style={undefined}
   >
     <div

--- a/stories/Form.jsx
+++ b/stories/Form.jsx
@@ -34,11 +34,13 @@ storiesOf('Form', module)
             <Form.Checkbox
               label='Check me out !'
               id='hello'
+              value='good'
               disabled={disabled}
             />
             <Form.Checkbox
               label='No, check ME out !'
               id='hello2'
+              value='better'
               disabled={disabled}
             />
           </Form.Group>


### PR DESCRIPTION
I added the [`jest-styled-components`](https://github.com/styled-components/jest-styled-components) package that prevent Jest snapshots to break when a new Styled Component is added to our tree.

The bug was reported [here](https://github.com/styled-components/jest-styled-components/issues/29).

This might actually fix part of #24.

P.S: i also added the `value` prop as `isRequired` for `Checkbox`, I hope you don't mind.